### PR TITLE
created a snippet for size variant, rendered in product page, related…

### DIFF
--- a/assets/component-price.css
+++ b/assets/component-price.css
@@ -20,7 +20,7 @@
 
 .price .price-item {
   display: inline-block;
-  margin: 0 1rem 0 0;
+  margin: 0;
 }
 
 .price__regular .price-item--regular {

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -445,43 +445,38 @@
           >
             <span class="sr-only">Product pricing</span>
             <div class="flex items-center gap-2">
-              <span
-                id="current-price"
-                style="font-weight: {{section.settings.product_price_font_weight}};"
-                aria-label="Current price"
-              >
-                {{- product.price | money -}}
-              </span>
-              <span
-                id="compare-price-separator"
-                class="text-black{% unless product.compare_at_price > product.price %}hidden{% endunless %}"
-                aria-hidden="true"
-                >|</span
-              >
-              <span
-                id="compare-price"
-                class="line-through{% unless product.compare_at_price > product.price %}hidden{% endunless %}"
-                style="color: var(--secondary_text);"
-                aria-label="Original price"
-              >
-                {% if product.compare_at_price > product.price %}{{ product.compare_at_price | money }}{% endif %}
-              </span>
+              {% render 'price',
+                product: product,
+                use_variant: true,
+                show_compare_at_price: true,
+                font_weight_desktop: section.settings.product_price_font_weight,
+                price_class: 'main-product-price'
+              %}
             </div>
 
             <div
               id="savings-info"
-              class="font-medium {% unless product.compare_at_price > product.price %}hidden{% endunless %}"
+              class="font-medium {% unless product.selected_or_first_available_variant.compare_at_price and product.selected_or_first_available_variant.compare_at_price > product.selected_or_first_available_variant.price %}hidden{% endunless %}"
               style="color: var(--sale_badge);"
               role="status"
               aria-live="polite"
             >
-              {% if product.compare_at_price > product.price %}
-                Save {{ product.compare_at_price | minus: product.price | money }} (
+              {% if product.selected_or_first_available_variant.compare_at_price
+                and product.selected_or_first_available_variant.compare_at_price
+                  > product.selected_or_first_available_variant.price
+              %}
+                Save
                 {{
-                  product.compare_at_price
-                  | minus: product.price
+                  product.selected_or_first_available_variant.compare_at_price
+                  | minus: product.selected_or_first_available_variant.price
+                  | money
+                }}
+                (
+                {{
+                  product.selected_or_first_available_variant.compare_at_price
+                  | minus: product.selected_or_first_available_variant.price
                   | times: 100
-                  | divided_by: product.compare_at_price
+                  | divided_by: product.selected_or_first_available_variant.compare_at_price
                 -}}
                 % off)
               {% endif %}
@@ -994,37 +989,39 @@
         <div class="text-[18px] flex flex-col justify-between" role="region" aria-labelledby="mobile-price-heading">
           <span id="mobile-price-heading" class="sr-only">Product pricing</span>
           <div class="flex items-center gap-2 pb-4">
-            <span
-              class="mobile-current-price"
-              aria-label="Current price"
-              style="font-size: var(--tm-b-1-size); line-height: var(--tm-b-1-line-height);"
-            >
-              {{- product.price | money -}}
-            </span>
-            <span
-              class="mobile-compare-price-separator{% unless product.compare_at_price > product.price %} hidden{% endunless %}"
-              aria-hidden="true"
-              style="font-size: var(--tm-b-2-size); line-height: var(--tm-b-2-line-height);"
-              >|</span
-            >
-            <span
-              class="mobile-compare-price line-through {% unless product.compare_at_price > product.price %}hidden{% endunless %}"
-              style="color: var(--secondary_text); font-size: var(--tm-b-1-size); line-height: var(--tm-b-1-line-height);"
-              aria-label="Original price"
-            >
-              {% if product.compare_at_price > product.price %}{{ product.compare_at_price | money }}{% endif %}
-            </span>
+            {% render 'price',
+              product: product,
+              use_variant: true,
+              show_compare_at_price: true,
+              font_size_mobile: 'var(--tm-b-1-size)',
+              line_height_mobile: 'var(--tm-b-1-line-height)',
+              price_class: 'mobile-main-product-price'
+            %}
           </div>
 
           <div
-            class="mobile-savings-info {% unless product.compare_at_price > product.price %}hidden{% endunless %}"
+            class="mobile-savings-info {% unless product.selected_or_first_available_variant.compare_at_price and product.selected_or_first_available_variant.compare_at_price > product.selected_or_first_available_variant.price %}hidden{% endunless %}"
             style="color: var(--sale_badge); font-size: var(--tm-b-1-size); line-height: var(--tm-b-1-line-height); padding-bottom: 10px;"
             role="status"
             aria-live="polite"
           >
-            {% if product.compare_at_price > product.price %}
-              Save {{ product.compare_at_price | minus: product.price | money }} (
-              {{ product.compare_at_price | minus: product.price | times: 100 | divided_by: product.compare_at_price -}}
+            {% if product.selected_or_first_available_variant.compare_at_price
+              and product.selected_or_first_available_variant.compare_at_price
+                > product.selected_or_first_available_variant.price
+            %}
+              Save
+              {{
+                product.selected_or_first_available_variant.compare_at_price
+                | minus: product.selected_or_first_available_variant.price
+                | money
+              }}
+              (
+              {{
+                product.selected_or_first_available_variant.compare_at_price
+                | minus: product.selected_or_first_available_variant.price
+                | times: 100
+                | divided_by: product.selected_or_first_available_variant.compare_at_price
+              -}}
               % off)
             {% endif %}
           </div>
@@ -1311,6 +1308,47 @@
                   transform: translateX(0) !important;
                 }
               }
+
+  /* Price snippet styling for main product page */
+  .main-product-price .price__regular,
+  .main-product-price .price__sale,
+  .mobile-main-product-price .price__regular,
+  .mobile-main-product-price .price__sale {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  /* Sale price styling - strikethrough for compare-at-price */
+  .main-product-price .price__sale .price-item--regular,
+  .mobile-main-product-price .price__sale .price-item--regular {
+    text-decoration: line-through;
+    color: var(--secondary_text);
+  }
+
+  /* Hide regular price section when on sale */
+  .main-product-price.price--on-sale .price__regular,
+  .mobile-main-product-price.price--on-sale .price__regular {
+    display: none !important;
+  }
+
+  /* Show sale price section when on sale */
+  .main-product-price.price--on-sale .price__sale,
+  .mobile-main-product-price.price--on-sale .price__sale {
+    display: flex !important;
+  }
+
+  /* Hide sale price section when not on sale */
+  .main-product-price:not(.price--on-sale) .price__sale,
+  .mobile-main-product-price:not(.price--on-sale) .price__sale {
+    display: none !important;
+  }
+
+  /* Show regular price section when not on sale */
+  .main-product-price:not(.price--on-sale) .price__regular,
+  .mobile-main-product-price:not(.price--on-sale) .price__regular {
+    display: flex !important;
+  }
 </style>
 <script>
 document.addEventListener('DOMContentLoaded', () => {
@@ -1880,24 +1918,31 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function updatePriceDisplay(variant, isMobile = false) {
-    const currentPriceEl = document.querySelector(isMobile ? '.mobile-current-price' : '#current-price');
-    const comparePriceEl = document.querySelector(isMobile ? '.mobile-compare-price' : '#compare-price');
-    const compareSeparatorEl = document.querySelector(isMobile ? '.mobile-compare-price-separator' : '#compare-price-separator');
+    const priceContainer = document.querySelector(isMobile ? '.mobile-main-product-price' : '.main-product-price');
     const savingsInfoEl = document.querySelector(isMobile ? '.mobile-savings-info' : '#savings-info');
 
-    if (!variant || !currentPriceEl) {
+    if (!variant || !priceContainer) {
       return;
     }
 
-    currentPriceEl.textContent = formatMoney(variant.price);
-
-    // Handle compare at price
-    if (variant.compare_at_price && variant.compare_at_price > variant.price) {
-      if (comparePriceEl) {
-        comparePriceEl.textContent = formatMoney(variant.compare_at_price);
-        comparePriceEl.classList.remove('hidden');
+    // Find all price elements and update them
+    const allPriceElements = priceContainer.querySelectorAll('.price-item');
+    allPriceElements.forEach(el => {
+      if (el.classList.contains('price-item--sale') || el.classList.contains('price-item--regular')) {
+        el.textContent = formatMoney(variant.price);
       }
-      if (compareSeparatorEl) compareSeparatorEl.classList.remove('hidden');
+    });
+
+    // Handle compare at price and update price container classes
+    if (variant.compare_at_price && variant.compare_at_price > variant.price) {
+      // Add sale class to show sale price section
+      priceContainer.classList.add('price--on-sale');
+      
+      // Update compare at price in the sale section
+      const saleComparePriceEl = priceContainer.querySelector('.price__sale .price-item--regular');
+      if (saleComparePriceEl) {
+        saleComparePriceEl.textContent = formatMoney(variant.compare_at_price);
+      }
       
       if (savingsInfoEl) {
         const savings = variant.compare_at_price - variant.price;
@@ -1906,9 +1951,12 @@ document.addEventListener('DOMContentLoaded', () => {
         savingsInfoEl.classList.remove('hidden');
       }
     } else {
-      if (comparePriceEl) comparePriceEl.classList.add('hidden');
-      if (compareSeparatorEl) compareSeparatorEl.classList.add('hidden');
-      if (savingsInfoEl) savingsInfoEl.classList.add('hidden');
+      // Remove sale class to show regular price section
+      priceContainer.classList.remove('price--on-sale');
+      
+      if (savingsInfoEl) {
+        savingsInfoEl.classList.add('hidden');
+      }
     }
   }
 

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -1099,9 +1099,6 @@
 </section>
 
 <style>
-  .size-btn{
-    border-radius: 5px;
-  }
         .gallery-item {
         display: block !important;
       }
@@ -1240,24 +1237,6 @@
                 height: calc(100% - 50px);
               }
 
-              .size-btn {
-                transition: all 0.3s ease;
-                 background-color: var(--button);
-              color: var(--button_label);
-              border: 1px solid var(--border);
-              }
-
-              .size-btn:not(:disabled):hover,
-              .size-btn.bg-black {
-              background-color: var(--hovered_button_label);
-              color: var(--hovered_button_text_color);
-              }
-
-              .size-btn:disabled {
-                opacity: 0.8;
-                cursor: not-allowed;
-                 border: 1px solid var(--border);
-              }
 
               /* Mobile-specific styles */
               @media (max-width: 1024px) {

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -427,55 +427,7 @@
         <!-- SIZE/DENOMINATION SELECTOR (no color) -->
         {% assign variant_option = null %}
         {% assign variant_option_index = 0 %}
-        {% for option in product.options_with_values %}
-          {% unless option.name == 'Color' or option.name == 'Colour' %}
-            {% assign variant_option = option %}
-            {% assign variant_option_index = forloop.index0 %}
-            {% break %}
-          {% endunless %}
-        {% endfor %}
-        {% if variant_option %}
-          <div class="flex justify-between items-center gap-2">
-            <span class="uppercase">SELECT {{ variant_option.name | upcase }}</span>
-            <div class="flex gap-2 flex-wrap">
-              {% for value in variant_option.values %}
-                {% assign variant_available = false %}
-                {% assign variant_id = null %}
-                {% for variant in product.variants %}
-                  {% assign option_key = 'option' | append: variant_option_index | plus: 1 %}
-                  {% if variant[option_key] == value %}
-                    {% if variant.available %}
-                      {% assign variant_available = true %}
-                      {% assign variant_id = variant.id %}
-                      {% break %}
-                    {% endif %}
-                  {% endif %}
-                {% endfor %}
-                <button
-                  type="button"
-                  class="
-                    size-btn relative px-3 h-10 min-w-[2.5rem] flex items-center justify-center border-transparent rounded border
-                    {% if forloop.first and variant_available %}bg-black text-white{% endif %}
-                    {% unless variant_available %}cursor-not-allowed bg-gray-200 unavailable-size{% endunless %}
-                  "
-                  data-option-index="{{ variant_option_index }}"
-                  data-value="{{ value | escape }}"
-                  {% if variant_available %}
-                    data-variant-id="{{ variant_id }}"
-                  {% else %}
-                    disabled aria-disabled="true"
-                  {% endif %}
-                  aria-label="{{ variant_option.name }} {{ value }}{% unless variant_available %} - Sold out{% endunless %}"
-                >
-                  <span class="label">{{ value }}</span>
-                  {% unless variant_available %}
-                    <span class="slash-unavailable"></span>
-                  {% endunless %}
-                </button>
-              {% endfor %}
-            </div>
-          </div>
-        {% endif %}
+        {% render 'size-variant-picker', product: product, mobile: false %}
         {% if product.gift_card? %}
           <div class="border-t border-gray-400 pt-4" style="padding-top: 1rem;">
             {% render 'gift-card-recipient-form', product: product, form: form, section: section %}
@@ -1029,63 +981,7 @@
       <!-- SIZE/DENOMINATION SELECTOR (no color) -->
       {% assign variant_option = null %}
       {% assign variant_option_index = 0 %}
-      {% for option in product.options_with_values %}
-        {% unless option.name == 'Color' or option.name == 'Colour' %}
-          {% assign variant_option = option %}
-          {% assign variant_option_index = forloop.index0 %}
-          {% break %}
-        {% endunless %}
-      {% endfor %}
-      {% if variant_option %}
-        <fieldset class="flex justify-between items-center gap-2" style="padding: 10px 0;" role="group">
-          <legend style="font-size: var(--tm-b-4-size); line-height: var(--tm-b-4-line-height);">
-            SELECT {{ variant_option.name | upcase }}
-          </legend>
-          <div class="flex gap-2 flex-wrap" role="radiogroup" aria-labelledby="mobile-size-legend">
-            <span id="mobile-size-legend" class="sr-only">{{ variant_option.name }} options</span>
-            {% for value in variant_option.values %}
-              {% assign variant_available = false %}
-              {% assign variant_id = null %}
-              {% for variant in product.variants %}
-                {% assign option_key = 'option' | append: variant_option_index | plus: 1 %}
-                {% if variant[option_key] == value %}
-                  {% if variant.available %}
-                    {% assign variant_available = true %}
-                    {% assign variant_id = variant.id %}
-                    {% break %}
-                  {% endif %}
-                {% endif %}
-              {% endfor %}
-              <button
-                type="button"
-                class="
-                  size-btn relative px-3 h-10 min-w-[2.5rem] flex items-center justify-center border-transparent rounded border
-                  focus:outline-none focus:ring-2 focus:ring-blue-500
-                  {% if forloop.first and variant_available %}bg-black text-white{% endif %}
-                  {% unless variant_available %} cursor-not-allowed bg-gray-200 unavailable-size{% endunless %}
-                "
-                data-option-index="{{ variant_option_index }}"
-                data-value="{{ value | escape }}"
-                role="radio"
-                aria-checked="{% if forloop.first and variant_available %}true{% else %}false{% endif %}"
-                {% if variant_available %}
-                  data-variant-id="{{ variant_id }}"
-                  tabindex="{% if forloop.first %}0{% else %}-1{% endif %}"
-                {% else %}
-                  disabled aria-disabled="true"
-                  tabindex="-1"
-                {% endif %}
-                aria-label="{{ variant_option.name }} {{ value }}{% unless variant_available %} - Sold out{% endunless %}"
-              >
-                <span class="label">{{ value }}</span>
-                {% unless variant_available %}
-                  <span class="slash-unavailable" aria-hidden="true"></span>
-                {% endunless %}
-              </button>
-            {% endfor %}
-          </div>
-        </fieldset>
-      {% endif %}
+      {% render 'size-variant-picker', product: product, mobile: true %}
       {% if product.gift_card? %}
         <div class="border-t border-gray-400 pt-4" style="padding-top: 1rem;">
           {% render 'gift-card-recipient-form', product: product, form: form, section: section %}
@@ -1206,6 +1102,9 @@
 </section>
 
 <style>
+  .size-btn{
+    border-radius: 5px;
+  }
         .gallery-item {
         display: block !important;
       }
@@ -1349,7 +1248,6 @@
                  background-color: var(--button);
               color: var(--button_label);
               border: 1px solid var(--border);
-              padding: 14px 10px;
               }
 
               .size-btn:not(:disabled):hover,
@@ -1362,7 +1260,6 @@
                 opacity: 0.8;
                 cursor: not-allowed;
                  border: 1px solid var(--border);
-                 padding: 14px 10px;
               }
 
               /* Mobile-specific styles */
@@ -1414,35 +1311,6 @@
                   transform: translateX(0) !important;
                 }
               }
-        .size-btn.unavailable-size {
-          opacity: 1;
-          visibility: visible;
-          position: relative;
-          cursor: not-allowed;
-          color: var(--text) !important;
-          border-color: var(--border) !important;
-          background-color: var(--disabled_text) !important;
-          overflow: hidden;
-          transform: translateY(0);
-          padding: 14px 10px;
-        }
-
-        .size-btn.unavailable-size:hover {
-          background-color: var(--disabled_text) !important;
-          transform: translateY(0);
-        }
-
-        .size-btn.unavailable-size::after {
-          content: '';
-          position: absolute;
-          top: 50%;
-          left: -2px;
-          right: -2px;
-          height: 2px;
-          background-color: var(--text);
-          transform: rotate(-45deg);
-          pointer-events: none;
-        }
 </style>
 <script>
 document.addEventListener('DOMContentLoaded', () => {

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -443,7 +443,7 @@
             role="region"
             aria-labelledby="price-heading"
           >
-            <span id="current-price" class="sr-only">Product pricing</span>
+            <span class="sr-only">Product pricing</span>
             <div class="flex items-center gap-2">
               <span
                 id="current-price"

--- a/snippets/new-product-card.liquid
+++ b/snippets/new-product-card.liquid
@@ -115,7 +115,12 @@
               <div class="new-size-label-wrapper">
                 <span class="new-size-label">Select Size</span>
                 <div class="new-size-options-wrapper" style="display: flex; gap: 5px;">
-                  {% render 'size-variant-picker', product: product, mobile: false, show_label: false %}
+                  {% render 'size-variant-picker',
+                    product: product,
+                    mobile: false,
+                    show_label: false,
+                    size_only: true
+                  %}
                 </div>
               </div>
             </div>

--- a/snippets/new-product-card.liquid
+++ b/snippets/new-product-card.liquid
@@ -115,42 +115,7 @@
               <div class="new-size-label-wrapper">
                 <span class="new-size-label">Select Size</span>
                 <div class="new-size-options-wrapper" style="display: flex; gap: 5px;">
-                  {% for option in product.options_with_values %}
-                    {% if option.name == 'Size' or option.name == 'size' %}
-                      {% for value in option.values %}
-                        {% assign variant_available = false %}
-                        {% assign variant_id = '' %}
-                        {% for variant in product_variants %}
-                          {% if variant.options[size_option_index] == value and variant.available %}
-                            {% assign variant_available = true %}
-                            {% assign variant_id = variant.id %}
-                            {% break %}
-                          {% endif %}
-                        {% endfor %}
-
-                        <button
-                          class="new-size-option-btn{% unless variant_available %} unavailable-size{% endunless %}"
-                          {% if variant_available %}
-                            data-variant-id="{{ variant_id }}"
-                            data-variant-size="{{ value }}"
-                            aria-label="Size {{ value }} available"
-                            type="button"
-                          {% else %}
-                            data-waitlist="true"
-                            data-product-title="{{ product_title }}"
-                            data-variant-size="{{ value }}"
-                            aria-label="Size {{ value }} unavailable, join waitlist"
-                            aria-disabled="true"
-                            type="button"
-                          {% endif %}
-                          style="--animation-order: {{ forloop.index0 }};"
-                        >
-                          {{ value }}
-                        </button>
-                      {% endfor %}
-                      {% break %}
-                    {% endif %}
-                  {% endfor %}
+                  {% render 'size-variant-picker', product: product, mobile: false, show_label: false %}
                 </div>
               </div>
             </div>
@@ -337,7 +302,7 @@
     width: min(381px, calc(255px + 0.1835 * (100vw - 425px) - 60px));
     left: 50%;
     transform: translateX(-50%) translateY(10px);
-    height: 37px;
+    height: 50px;
     border-radius: {{ settings.buttons_radius }}px;
     font-size: var(--t-b-2-size);
     font-weight: var(--t-b-2-weight);
@@ -367,7 +332,7 @@
     left: 50%;
     transform: translateX(-50%) translateY(10px);
     width: min(381px, calc(255px + 0.1835 * (100vw - 425px) - 60px));
-    height: 37px;
+    height: 50px;
     z-index: 10;
     transition: all 0.3s ease;
     display: flex;
@@ -384,6 +349,7 @@
     display: flex;
     width: 100%;
     align-items: center;
+    justify-content: space-between;
     border-radius: {{ settings.buttons_radius }}px;
   }
 
@@ -456,38 +422,6 @@
     transition: background-color 0.3s ease, color 0.3s ease, transform 0.3s ease;
   }
 
-  .unavailable-size {
-    opacity: 0;
-    visibility: hidden;
-    position: relative;
-    cursor: not-allowed;
-    color: var(--text) !important;
-    border-color: var(--disabled_text) !important;
-    background-color: var(--disabled_text) !important;
-    overflow: hidden;
-    transform: translateY(10px);
-  }
-
-  .unavailable-size:hover {
-    background-color: var(--disabled_text) !important;
-    transform: translateY(-2px);
-    transition: background-color 0.3s ease, transform 0.3s ease;
-  }
-
-  .unavailable-size::after {
-    content: '';
-    position: absolute;
-    top: 50%;
-    left: -2px;
-    right: -2px;
-    height: 2px;
-    background-color: var(--text);
-    transform: rotate(-45deg);
-  }
-
-  .unavailable-size:hover::after {
-    height: 0px;
-  }
 
   .new-size-option-btn.size-animate {
     animation: sizeOptionAppear 0.5s ease forwards;

--- a/snippets/price.liquid
+++ b/snippets/price.liquid
@@ -120,8 +120,7 @@
           </span>
         {%- endunless -%}
         <span
-          id="compare-price-separator"
-          class="text-black{% unless compare_at_price > price %}hidden{% endunless %}"
+          class="price-separator text-black{% unless compare_at_price and compare_at_price > price %}hidden{% endunless %}"
           aria-hidden="true"
           >|</span
         >

--- a/snippets/price.liquid
+++ b/snippets/price.liquid
@@ -119,6 +119,12 @@
             </s>
           </span>
         {%- endunless -%}
+        <span
+          id="compare-price-separator"
+          class="text-black{% unless compare_at_price > price %}hidden{% endunless %}"
+          aria-hidden="true"
+          >|</span
+        >
         <span class="visually-hidden visually-hidden--inline">{{ 'products.product.price.sale_price' | t }}</span>
         <span class="price-item price-item--sale price-item--last">
           {{ money_price }}
@@ -164,7 +170,6 @@
   .new-product-price .price__container {
     display: flex;
     align-items: center;
-    gap: 8px;
   }
 
   .new-product-price .price__regular,

--- a/snippets/size-variant-picker.liquid
+++ b/snippets/size-variant-picker.liquid
@@ -1,0 +1,200 @@
+{% comment %}
+  Unified Size Variant Picker Snippet
+  Works for both mobile and desktop with responsive styling
+  Usage: {% render 'size-variant-picker', product: product, mobile: true/false, show_label: true/false %}
+{% endcomment %}
+
+{%- liquid
+  assign variant_option = null
+  assign variant_option_index = null
+
+  for option in product.options_with_values
+    if option.name == 'Size' or option.name == 'size'
+      assign variant_option = option
+      assign variant_option_index = forloop.index0
+      break
+    endif
+  endfor
+-%}
+
+{% if variant_option %}
+  {% if mobile %}
+    <!-- Mobile Version -->
+    <fieldset class="flex justify-between items-center gap-2" style="padding: 10px 0;" role="group">
+      <legend style="font-size: var(--tm-b-4-size); line-height: var(--tm-b-4-line-height);">
+        SELECT {{ variant_option.name | upcase }}
+      </legend>
+      <div class="flex gap-2 flex-wrap" role="radiogroup" aria-labelledby="mobile-size-legend">
+        <span id="mobile-size-legend" class="sr-only">{{ variant_option.name }} options</span>
+        {% for value in variant_option.values %}
+          {% assign variant_available = false %}
+          {% assign variant_id = null %}
+          {% for variant in product.variants %}
+            {% assign option_key = 'option' | append: variant_option_index | plus: 1 %}
+            {% if variant[option_key] == value %}
+              {% if variant.available %}
+                {% assign variant_available = true %}
+                {% assign variant_id = variant.id %}
+                {% break %}
+              {% endif %}
+            {% endif %}
+          {% endfor %}
+          <button
+            type="button"
+            class="
+              size-btn relative px-3 h-10 min-w-[2.5rem] flex items-center justify-center border-transparent rounded border
+              focus:outline-none focus:ring-2 focus:ring-blue-500
+              {% if forloop.first and variant_available %}bg-black text-white{% endif %}
+              {% unless variant_available %} cursor-not-allowed unavailable-size{% endunless %}
+            "
+            data-option-index="{{ variant_option_index }}"
+            data-value="{{ value | escape }}"
+            role="radio"
+            aria-checked="{% if forloop.first and variant_available %}true{% else %}false{% endif %}"
+            {% if variant_available %}
+              data-variant-id="{{ variant_id }}"
+              tabindex="{% if forloop.first %}0{% else %}-1{% endif %}"
+            {% else %}
+              disabled aria-disabled="true"
+              tabindex="-1"
+            {% endif %}
+            aria-label="{{ variant_option.name }} {{ value }}{% unless variant_available %} - Sold out{% endunless %}"
+          >
+            <span class="label">{{ value }}</span>
+            {% unless variant_available %}
+              <span class="slash-unavailable" aria-hidden="true"></span>
+            {% endunless %}
+          </button>
+        {% endfor %}
+      </div>
+    </fieldset>
+  {% else %}
+    <!-- Desktop Version -->
+    <div class="flex justify-between items-center gap-2">
+      {% if show_label != false %}
+        <span class="uppercase">SELECT {{ variant_option.name | upcase }}</span>
+      {% endif %}
+      <div class="flex gap-2 flex-wrap">
+        {% for value in variant_option.values %}
+          {% assign variant_available = false %}
+          {% assign variant_id = null %}
+          {% for variant in product.variants %}
+            {% assign option_key = 'option' | append: variant_option_index | plus: 1 %}
+            {% if variant[option_key] == value %}
+              {% if variant.available %}
+                {% assign variant_available = true %}
+                {% assign variant_id = variant.id %}
+                {% break %}
+              {% endif %}
+            {% endif %}
+          {% endfor %}
+          <button
+            type="button"
+            class="
+              size-btn relative px-3 h-10 min-w-[2.5rem] flex items-center justify-center border-transparent border
+              {% if forloop.first and variant_available %}bg-black text-white{% endif %}
+              {% unless variant_available %}cursor-not-allowed unavailable-size{% endunless %}
+            "
+            data-option-index="{{ variant_option_index }}"
+            data-value="{{ value | escape }}"
+            {% if variant_available %}
+              data-variant-id="{{ variant_id }}"
+            {% else %}
+              disabled aria-disabled="true"
+            {% endif %}
+            aria-label="{{ variant_option.name }} {{ value }}{% unless variant_available %} - Sold out{% endunless %}"
+          >
+            <span class="label">{{ value }}</span>
+            {% unless variant_available %}
+              <span class="slash-unavailable"></span>
+            {% endunless %}
+          </button>
+        {% endfor %}
+      </div>
+    </div>
+  {% endif %}
+{% else %}
+  <!-- Default title when no size option exists -->
+  {% if mobile %}
+    <div class="flex justify-between items-center gap-2" style="padding: 10px 0;">
+      <span style="font-size: var(--tm-b-4-size); line-height: var(--tm-b-4-line-height);"> SELECT OPTION </span>
+    </div>
+  {% else %}
+    <div class="flex justify-between items-center gap-2">
+      <span class="uppercase">SELECT OPTION</span>
+    </div>
+  {% endif %}
+{% endif %}
+
+<style>
+  .size-btn {
+    border-radius: 5px;
+    transition: all 0.3s ease;
+    background-color: var(--button);
+    color: var(--button_label);
+    border: 1px solid var(--disabled_text);
+  }
+
+  .size-btn:not(:disabled):hover,
+  .size-btn.bg-black {
+    background-color: var(--hovered_button_label);
+    color: var(--hovered_button_text_color);
+  }
+
+  .size-btn:disabled {
+    opacity: 0.8;
+    cursor: not-allowed;
+    border: 1px solid var(--disabled_text);
+  }
+
+  .size-btn.unavailable-size {
+    opacity: 1;
+    visibility: visible;
+    position: relative;
+    cursor: not-allowed;
+    color: var(--text) !important;
+    border-color: var(--disabled_text) !important;
+    background-color: var(--disabled_text) !important;
+    overflow: hidden;
+    transform: translateY(0);
+  }
+
+  .size-btn.unavailable-size:hover {
+    background-color: var(--disabled_text) !important;
+    transform: translateY(0);
+  }
+
+  .size-btn.unavailable-size::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 0;
+    right: 0;
+    height: 1px;
+    background-color: var(--text);
+    transform: rotate(-42deg) translateY(-50%);
+    transform-origin: center;
+    pointer-events: none;
+    width: 125%;
+  }
+
+  .slash-unavailable {
+    position: absolute;
+    top: 50%;
+    left: 0;
+    right: 0;
+    height: 1px;
+    background-color: var(--text);
+    transform: rotate(-42deg) translateY(-50%);
+    transform-origin: center;
+    pointer-events: none;
+    z-index: 10;
+    width: 125%;
+  }
+
+  .size-btn.unavailable-size:hover .slash-unavailable {
+    background-color: var(--text) !important;
+    opacity: 1 !important;
+    visibility: visible !important;
+  }
+</style>

--- a/snippets/size-variant-picker.liquid
+++ b/snippets/size-variant-picker.liquid
@@ -1,5 +1,6 @@
 {% comment %}
-  Unified Size Variant Picker Snippet
+  Unified Variant Picker Snippet
+  Handles any non-color variant option (Size, Denomination, Material, Type, etc.)
   Works for both mobile and desktop with responsive styling
   Usage: {% render 'size-variant-picker', product: product, mobile: true/false, show_label: true/false %}
 {% endcomment %}
@@ -9,11 +10,11 @@
   assign variant_option_index = null
 
   for option in product.options_with_values
-    if option.name == 'Size' or option.name == 'size'
+    unless option.name == 'Color' or option.name == 'Colour'
       assign variant_option = option
       assign variant_option_index = forloop.index0
       break
-    endif
+    endunless
   endfor
 -%}
 
@@ -114,7 +115,7 @@
     </div>
   {% endif %}
 {% else %}
-  <!-- Default title when no size option exists -->
+  <!-- Default title when no non-color variant option exists -->
   {% if mobile %}
     <div class="flex justify-between items-center gap-2" style="padding: 10px 0;">
       <span style="font-size: var(--tm-b-4-size); line-height: var(--tm-b-4-line-height);"> SELECT OPTION </span>

--- a/snippets/size-variant-picker.liquid
+++ b/snippets/size-variant-picker.liquid
@@ -2,19 +2,32 @@
   Unified Variant Picker Snippet
   Handles any non-color variant option (Size, Denomination, Material, Type, etc.)
   Works for both mobile and desktop with responsive styling
-  Usage: {% render 'size-variant-picker', product: product, mobile: true/false, show_label: true/false %}
+  Usage: {% render 'size-variant-picker', product: product, mobile: true/false, show_label: true/false, size_only: true/false %}
 {% endcomment %}
 
 {%- liquid
   assign variant_option = null
   assign variant_option_index = null
+  assign has_any_variants = false
 
   for option in product.options_with_values
-    unless option.name == 'Color' or option.name == 'Colour'
-      assign variant_option = option
-      assign variant_option_index = forloop.index0
-      break
-    endunless
+    assign has_any_variants = true
+
+    if size_only == true
+      # For product cards, only show Size variants
+      if option.name == 'Size' or option.name == 'size'
+        assign variant_option = option
+        assign variant_option_index = forloop.index0
+        break
+      endif
+    else
+      # For main product page, show any non-color variant
+      unless option.name == 'Color' or option.name == 'Colour'
+        assign variant_option = option
+        assign variant_option_index = forloop.index0
+        break
+      endunless
+    endif
   endfor
 -%}
 
@@ -52,6 +65,7 @@
             data-value="{{ value | escape }}"
             role="radio"
             aria-checked="{% if forloop.first and variant_available %}true{% else %}false{% endif %}"
+            style="--animation-order: {{ forloop.index0 }};"
             {% if variant_available %}
               data-variant-id="{{ variant_id }}"
               tabindex="{% if forloop.first %}0{% else %}-1{% endif %}"
@@ -98,6 +112,7 @@
             "
             data-option-index="{{ variant_option_index }}"
             data-value="{{ value | escape }}"
+            style="--animation-order: {{ forloop.index0 }};"
             {% if variant_available %}
               data-variant-id="{{ variant_id }}"
             {% else %}
@@ -114,8 +129,8 @@
       </div>
     </div>
   {% endif %}
-{% else %}
-  <!-- Default title when no non-color variant option exists -->
+{% elsif has_any_variants %}
+  <!-- Show SELECT OPTION only when there are variants but no non-color ones -->
   {% if mobile %}
     <div class="flex justify-between items-center gap-2" style="padding: 10px 0;">
       <span style="font-size: var(--tm-b-4-size); line-height: var(--tm-b-4-line-height);"> SELECT OPTION </span>
@@ -183,5 +198,60 @@
     background-color: var(--text) !important;
     opacity: 1 !important;
     visibility: visible !important;
+  }
+
+  /* Animation for size buttons */
+  .size-btn.size-animate {
+    animation: sizeOptionAppear 0.5s ease forwards;
+    animation-delay: calc(0.15s * var(--animation-order));
+  }
+
+  @keyframes sizeOptionAppear {
+    0% {
+      opacity: 0;
+      transform: translateY(10px);
+      visibility: hidden;
+    }
+    100% {
+      opacity: 1;
+      transform: translateY(0);
+      visibility: visible;
+    }
+  }
+
+  /* Animation only applies to product cards, not main product page */
+  .new-size-options-wrapper .size-btn {
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(10px);
+  }
+
+  /* Animate in when container is active or on hover */
+  .new-size-variants-container.active .size-btn,
+  .new-add-to-cart-btn:hover + .new-size-variants-container .size-btn {
+    animation: sizeOptionAppear 0.5s ease forwards;
+    animation-delay: calc(0.15s * var(--animation-order));
+  }
+
+  /* Specific animation delays for better staggered effect */
+  .new-size-variants-container.active .size-btn:nth-child(1),
+  .new-add-to-cart-btn:hover + .new-size-variants-container .size-btn:nth-child(1) {
+    animation-delay: 0s;
+  }
+  .new-size-variants-container.active .size-btn:nth-child(2),
+  .new-add-to-cart-btn:hover + .new-size-variants-container .size-btn:nth-child(2) {
+    animation-delay: 0.1s;
+  }
+  .new-size-variants-container.active .size-btn:nth-child(3),
+  .new-add-to-cart-btn:hover + .new-size-variants-container .size-btn:nth-child(3) {
+    animation-delay: 0.2s;
+  }
+  .new-size-variants-container.active .size-btn:nth-child(4),
+  .new-add-to-cart-btn:hover + .new-size-variants-container .size-btn:nth-child(4) {
+    animation-delay: 0.3s;
+  }
+  .new-size-variants-container.active .size-btn:nth-child(5),
+  .new-add-to-cart-btn:hover + .new-size-variants-container .size-btn:nth-child(5) {
+    animation-delay: 0.4s;
   }
 </style>

--- a/snippets/size-variant-picker.liquid
+++ b/snippets/size-variant-picker.liquid
@@ -165,20 +165,6 @@
     transform: translateY(0);
   }
 
-  .size-btn.unavailable-size::after {
-    content: '';
-    position: absolute;
-    top: 50%;
-    left: 0;
-    right: 0;
-    height: 1px;
-    background-color: var(--text);
-    transform: rotate(-42deg) translateY(-50%);
-    transform-origin: center;
-    pointer-events: none;
-    width: 125%;
-  }
-
   .slash-unavailable {
     position: absolute;
     top: 50%;


### PR DESCRIPTION
… products and featured collection

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a unified size-variant picker snippet and migrates PDP/mobile and product cards to the shared price/variant UI with variant-aware sale handling and styling updates.
> 
> - **PDP (sections/main-product.liquid)**
>   - Replace inline size/denomination selectors with `snippets/size-variant-picker.liquid` (desktop and mobile).
>   - Switch price display to shared `snippets/price.liquid` for desktop/mobile; update savings to use `selected_or_first_available_variant`.
>   - JS: `updatePriceDisplay` now targets `.main-product-price`/`.mobile-main-product-price`, toggles `price--on-sale`, and updates elements within the price snippet; removes legacy element updates.
>   - Add local CSS to style main/mobile price containers and sale/regular visibility.
> - **Product Card (snippets/new-product-card.liquid)**
>   - Render `size-variant-picker` (size-only, no label) in the card; remove inline size option generation.
>   - Adjust button/variants container heights to 50px and layout spacing.
> - **New Snippet**: `snippets/size-variant-picker.liquid`
>   - Unified non-color variant picker (desktop/mobile), includes accessibility attributes and unavailable state styling/animation.
> - **Price Snippet (snippets/price.liquid)**
>   - Add optional separator in sale layout; minor CSS tweaks (container alignment, sale/regular visibility). Keeps responsive font controls.
> - **Styles**
>   - `assets/component-price.css`: remove right margin from `.price .price-item`.
>   - Add page-level styles for `.main-product-price`/`.mobile-main-product-price` sale/regular states.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe3f741c0f427b9f12894e432e807d685ae06e23. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->