### PR TITLE
 scrolling text fies, background color and default text

### DIFF
--- a/sections/scrolling-text-banner.liquid
+++ b/sections/scrolling-text-banner.liquid
@@ -68,7 +68,7 @@
       "type": "color",
       "id": "top_strip_bg_color",
       "label": "Top Strip Background Color",
-      "default": "#dc2626"
+      "default": "#000000"
     },
     {
       "type": "color",
@@ -171,20 +171,20 @@
         {
           "type": "top_strip_block",
           "settings": {
-            "text": "BANDIT GRAND PRIX"
+            "text": "FREE SHIPPING ON ORDERS OVER $50"
           }
         },
         {
           "type": "middle_strip_block",
           "settings": {
-            "large_text": "JULY 5TH",
-            "small_text": "BROOKLYN"
+            "large_text": "NEW ARRIVALS",
+            "small_text": "EXPLORE THE COLLECTION"
           }
         },
         {
           "type": "bottom_strip_block",
           "settings": {
-            "text": "OPEN HEATS"
+            "text": "SIGN UP FOR OUR NEWSLETTER & SAVE"
           }
         }
       ]
@@ -193,7 +193,6 @@
 }
 {% endschema %}
 
-
 {%- liquid
   # Sanitize and validate settings
   assign banner_height = section.settings.banner_height | default: 55
@@ -201,26 +200,26 @@
   assign separator_size = section.settings.separator_size | default: 30
   assign pause_on_hover = section.settings.pause_on_hover | default: false
   assign background_color = section.settings.background_color | default: '#ffffff'
-  
+
   # Validate ranges
   if banner_height < 45
     assign banner_height = 45
   elsif banner_height > 150
     assign banner_height = 150
   endif
-  
+
   if scroll_speed < 5
     assign scroll_speed = 5
   elsif scroll_speed > 50
     assign scroll_speed = 50
   endif
-  
+
   if separator_size < 10
     assign separator_size = 10
   elsif separator_size > 60
     assign separator_size = 60
   endif
-  
+
   # Get blocks by type
   assign top_blocks = section.blocks | where: 'type', 'top_strip_block'
   assign middle_blocks = section.blocks | where: 'type', 'middle_strip_block'
@@ -231,14 +230,14 @@
   /* Scrolling Text Banner Styles */
   .middle-strip-item .small-text {
     display: inline-block;
-    max-width: 100px;           
+    max-width: 100px;
     word-wrap: break-word;
   }
-  
+
   * {
     box-sizing: border-box;
   }
-  
+
   .scrolling-text-section1 {
     overflow: hidden;
     background-color: {{ background_color }};
@@ -246,7 +245,7 @@
     padding-bottom: 20px;
     position: relative;
   }
-  
+
   .scrolling-banner {
     white-space: nowrap;
     overflow: hidden;
@@ -257,7 +256,7 @@
     padding-top: 15px;
     padding-bottom: 15px;
   }
-  
+
   .scrolling-text-wrapper,
   .scrolling-text-top-wrapper,
   .scrolling-text-slow-wrapper {
@@ -268,19 +267,19 @@
     align-items: center;
     will-change: transform;
   }
-  
+
   .scrolling-text-wrapper {
     animation: scrollInfinite {{ scroll_speed | times: 4 }}s linear infinite;
   }
-  
+
   .scrolling-text-top-wrapper {
     animation: scrollInfinite {{ scroll_speed | times: 4 }}s linear infinite;
   }
-  
+
   .scrolling-text-slow-wrapper {
     animation: scrollInfinite {{ scroll_speed | times: 1.8 }}s linear infinite;
   }
-  
+
   {% if pause_on_hover %}
   .scrolling-text-wrapper:hover,
   .scrolling-text-top-wrapper:hover,
@@ -288,7 +287,7 @@
     animation-play-state: paused;
   }
   {% endif %}
-  
+
   .text-item {
     font-weight: 500;
     letter-spacing: -0.02em;
@@ -300,7 +299,7 @@
     flex-shrink: 0;
     word-spacing:10px;
   }
-  
+
   .separator {
     margin-right: 15px;
     display: inline-flex;
@@ -308,7 +307,7 @@
     height: 100%;
     flex-shrink: 0;
   }
-  
+
   .separator img {
     height: {{ separator_size }}px;
     width: auto;
@@ -316,19 +315,19 @@
     display: block;
     max-width: none;
   }
-  
+
   .separator-text {
     font-size: 40px;
     font-weight: 500;
   }
-  
+
   .middle-strip-item {
     display: inline-flex;
     align-items: center;
     margin-right: 30px;
     flex-shrink: 0;
   }
-  
+
   .large-text {
     font-weight: 500;
     letter-spacing: -0.03em;
@@ -337,7 +336,7 @@
     display: inline-block;
     margin-right: 15px;
   }
-  
+
   .small-text {
     font-weight: 500;
     letter-spacing: -0.02em;
@@ -348,14 +347,14 @@
     white-space: normal;
     width: max-content;
     margin-left: 20px;
-    margin-right: -5px; 
+    margin-right: -5px;
   }
-  
+
   .small-text-line {
     display: block;
     margin-bottom: 2px;
   }
-  
+
   @keyframes scrollInfinite {
     0% {
       transform: translateX(-50%);
@@ -364,42 +363,42 @@
       transform: translateX(0);
     }
   }
-  
+
   .banner-strip {
     transform: rotate(-1deg);
     padding: 5px 0px;
     overflow: visible;
     position: relative;
   }
-  
+
   .top-strip {
     background-color: {{ section.settings.top_strip_bg_color }};
     margin-top: 15px;
   }
-  
+
   .middle-strip {
     background-color: {{ section.settings.middle_strip_bg_color }};
   }
-  
+
   .bottom-strip {
     background-color: {{ section.settings.bottom_strip_bg_color }};
   }
-  
+
   .top-strip .text-item,
   .top-strip .separator-text {
     color: {{ section.settings.top_strip_text_color }};
   }
-  
+
   .middle-strip .large-text,
   .middle-strip .small-text {
     color: {{ section.settings.middle_strip_text_color }};
   }
-  
+
   .bottom-strip .text-item,
   .bottom-strip .separator-text {
     color: {{ section.settings.bottom_strip_text_color }};
   }
-  
+
   /* Reduced motion support */
   @media (prefers-reduced-motion: reduce) {
     .scrolling-text-wrapper,
@@ -408,14 +407,14 @@
       animation-duration: {{ scroll_speed | times: 8 }}s;
     }
   }
-  
+
   /* High contrast mode support */
   @media (prefers-contrast: high) {
     .banner-strip {
       border: 1px solid currentColor;
     }
   }
-  
+
   /* Mobile responsive styles */
   @media (max-width: 480px) {
     .scrolling-text-section1 {
@@ -424,66 +423,71 @@
       padding-top: 10px;
       padding-bottom: 10px;
     }
-    
+
     .scrolling-banner {
       height: 30px;
       padding-top: 10px;
       padding-bottom: 10px;
     }
-    
+
     .large-text {
       font-size: 30px;
       margin-left: -16px;
     }
-    
+
     .text-item {
       font-size: 30px;
       margin-right:-1px;
     }
-    
+
     .separator-text {
       font-size: 20px;
     }
-    
+
     .separator img {
       height: {{ separator_size | divided_by: 2 }}px;
     }
-    
+
     .small-text {
       font-size: 13px;
       margin-left: 6px;
       margin-right: -14px;
     }
-    
+
     .separator {
       margin: 0 8px;
     }
   }
 </style>
 
-<section class="scrolling-text-section1" 
-         role="banner" 
-         aria-label="Scrolling text banner"
-         {{ section.shopify_attributes }}>
-  
+<section
+  class="scrolling-text-section1"
+  role="banner"
+  aria-label="Scrolling text banner"
+  {{ section.shopify_attributes }}
+>
   <!-- Top Rotated Strip -->
   {%- if top_blocks.size > 0 -%}
     <div class="banner-strip top-strip">
       <div class="scrolling-banner">
-        <div class="scrolling-text-top-wrapper" 
-             role="marquee" 
-             aria-label="Top scrolling text">
+        <div
+          class="scrolling-text-top-wrapper"
+          role="marquee"
+          aria-label="Top scrolling text"
+        >
           {%- for i in (1..20) -%}
             {%- for block in top_blocks -%}
               {%- if block.settings.text != blank -%}
                 <span class="text-item">{{ block.settings.text | escape }}</span>
                 {%- if block.settings.separator_image -%}
                   <span class="separator">
-                    <img src="{{ block.settings.separator_image | image_url: width: 100 }}" 
-                         alt="Separator"
-                         loading="lazy"
-                         width="{{ separator_size }}"
-                         height="{{ separator_size }}">
+                    <img
+                      src="{{ block.settings.separator_image | image_url: width: 100 }}"
+                      alt="Separator"
+                      loading="lazy"
+                      width="{{ separator_size }}"
+                      height="{{ separator_size }}"
+                    >
                   </span>
                 {%- endif -%}
               {%- endif -%}
@@ -493,14 +497,16 @@
       </div>
     </div>
   {%- endif -%}
-  
+
   <!-- Middle Rotated Strip -->
   {%- if middle_blocks.size > 0 -%}
     <div class="banner-strip middle-strip">
       <div class="scrolling-banner">
-        <div class="scrolling-text-wrapper" 
-             role="marquee" 
-             aria-label="Middle scrolling text">
+        <div
+          class="scrolling-text-wrapper"
+          role="marquee"
+          aria-label="Middle scrolling text"
+        >
           {%- for i in (1..20) -%}
             {%- for block in middle_blocks -%}
               {%- if block.settings.large_text != blank or block.settings.small_text != blank -%}
@@ -519,25 +525,29 @@
       </div>
     </div>
   {%- endif -%}
-  
+
   <!-- Bottom Rotated Strip -->
   {%- if bottom_blocks.size > 0 -%}
     <div class="banner-strip bottom-strip">
       <div class="scrolling-banner">
-        <div class="scrolling-text-slow-wrapper" 
-             role="marquee" 
-             aria-label="Bottom scrolling text">
+        <div
+          class="scrolling-text-slow-wrapper"
+          role="marquee"
+          aria-label="Bottom scrolling text"
+        >
           {%- for i in (1..20) -%}
             {%- for block in bottom_blocks -%}
               {%- if block.settings.text != blank -%}
                 <span class="text-item">{{ block.settings.text | escape }}</span>
                 {%- if block.settings.separator_image -%}
                   <span class="separator">
-                    <img src="{{ block.settings.separator_image | image_url: width: 100 }}" 
-                         alt="Separator"
-                         loading="lazy"
-                         width="{{ separator_size }}"
-                         height="{{ separator_size }}">
+                    <img
+                      src="{{ block.settings.separator_image | image_url: width: 100 }}"
+                      alt="Separator"
+                      loading="lazy"
+                      width="{{ separator_size }}"
+                      height="{{ separator_size }}"
+                    >
                   </span>
                 {%- endif -%}
               {%- endif -%}
@@ -551,43 +561,44 @@
 
 <script>
   // Initialize scrolling text banner functionality
-  document.addEventListener('DOMContentLoaded', function() {
-    const scrollingWrappers = document.querySelectorAll('.scrolling-text-wrapper, .scrolling-text-top-wrapper, .scrolling-text-slow-wrapper');
-    
+  document.addEventListener('DOMContentLoaded', function () {
+    const scrollingWrappers = document.querySelectorAll(
+      '.scrolling-text-wrapper, .scrolling-text-top-wrapper, .scrolling-text-slow-wrapper'
+    );
+
     function initializeScrollingBanner() {
-      scrollingWrappers.forEach(function(wrapper) {
+      scrollingWrappers.forEach(function (wrapper) {
         const containerWidth = window.innerWidth;
         const wrapperWidth = wrapper.scrollWidth;
-        
+
         // Ensure we have enough content for seamless scrolling
         if (wrapperWidth < containerWidth * 2) {
           const content = wrapper.innerHTML;
           wrapper.innerHTML = content + content;
         }
-        
+
         // Add focus management for accessibility
-        wrapper.addEventListener('focus', function() {
+        wrapper.addEventListener('focus', function () {
           this.style.animationPlayState = 'paused';
         });
-        
-        wrapper.addEventListener('blur', function() {
+
+        wrapper.addEventListener('blur', function () {
           this.style.animationPlayState = 'running';
         });
-        
+
         // Ensure smooth animation start
         wrapper.style.animationDelay = '0s';
       });
     }
-    
+
     // Initialize on load
     initializeScrollingBanner();
-    
+
     // Reinitialize on window resize to maintain proper scrolling
     let resizeTimeout;
-    window.addEventListener('resize', function() {
+    window.addEventListener('resize', function () {
       clearTimeout(resizeTimeout);
       resizeTimeout = setTimeout(initializeScrollingBanner, 250);
     });
   });
 </script>
-


### PR DESCRIPTION
default colors and text fix

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates `sections/scrolling-text-banner.liquid` to set a black default for the top strip background and refresh preset texts for all three strips.
> 
> - **Theme Section `sections/scrolling-text-banner.liquid`**
>   - **Defaults**: Set `top_strip_bg_color` default to `#000000`.
>   - **Presets**:
>     - Top strip `text`: `FREE SHIPPING ON ORDERS OVER $50`.
>     - Middle strip `large_text`: `NEW ARRIVALS`; `small_text`: `EXPLORE THE COLLECTION`.
>     - Bottom strip `text`: `SIGN UP FOR OUR NEWSLETTER & SAVE`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b060253554ad86e905b9216ef766b966f69224a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->