### PR TITLE
fixes for tokens in scrolling

### DIFF
--- a/sections/scrolling-text-banner.liquid
+++ b/sections/scrolling-text-banner.liquid
@@ -86,7 +86,7 @@
       "type": "color",
       "id": "middle_strip_text_color",
       "label": "Middle Strip Text Color",
-      "default": "#dc2626"
+      "default": "#000000"
     },
     {
       "type": "color",
@@ -98,7 +98,7 @@
       "type": "color",
       "id": "bottom_strip_text_color",
       "label": "Bottom Strip Text Color",
-      "default": "#dc2626"
+      "default": "#FFFFFF"
     }
   ],
   "blocks": [
@@ -241,8 +241,8 @@
   .scrolling-text-section1 {
     overflow: hidden;
     background-color: {{ background_color }};
-    padding-top: 20px;
-    padding-bottom: 20px;
+    padding-top: var(--space-3xl);
+    padding-bottom: var(--space-3xl);
     position: relative;
   }
 
@@ -253,8 +253,8 @@
     display: flex;
     align-items: center;
     position: relative;
-    padding-top: 15px;
-    padding-bottom: 15px;
+    padding-top: var(--space-2xl);
+    padding-bottom: var(--space-2xl);
   }
 
   .scrolling-text-wrapper,
@@ -295,13 +295,13 @@
     font-size: 70px;
     display: inline-flex;
     align-items: center;
-    margin-right: 20px;
+    margin-right: var(--space-3xl);
     flex-shrink: 0;
     word-spacing:10px;
   }
 
   .separator {
-    margin-right: 15px;
+    margin-right: var(--space-2xl);
     display: inline-flex;
     align-items: center;
     height: 100%;
@@ -334,7 +334,7 @@
     line-height: 1.2;
     font-size: 70px;
     display: inline-block;
-    margin-right: 15px;
+    margin-right: var(--space-2xl);
   }
 
   .small-text {
@@ -346,7 +346,7 @@
     text-align: left;
     white-space: normal;
     width: max-content;
-    margin-left: 20px;
+    margin-left: var(--space-3xl);
     margin-right: -5px;
   }
 
@@ -373,7 +373,7 @@
 
   .top-strip {
     background-color: {{ section.settings.top_strip_bg_color }};
-    margin-top: 15px;
+    margin-top: var(--space-2xl);
   }
 
   .middle-strip {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replaces hardcoded px spacing with design tokens in `sections/scrolling-text-banner.liquid` and updates default middle/bottom text colors.
> 
> - **Styling (sections/scrolling-text-banner.liquid)**:
>   - Replace hardcoded padding/margin values with spacing tokens (`var(--space-2xl/3xl)`) for `.scrolling-text-section1`, `.scrolling-banner`, `.text-item`, `.separator`, `.large-text`, `.small-text`, and `.top-strip`.
> - **Defaults**:
>   - `middle_strip_text_color` default: `#dc2626` → `#000000`.
>   - `bottom_strip_text_color` default: `#dc2626` → `#FFFFFF`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce1b35f7d12f89cc11875145a4ece10cd94983d1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->