### PR TITLE
Added playback button common functionality in whole theme

### DIFF
--- a/assets/caret-right-fill2.svg
+++ b/assets/caret-right-fill2.svg
@@ -1,3 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-caret-right-fill" viewBox="0 0 16 16">
-  <path d="m12.14 8.753-5.482 4.796c-.646.566-1.658.106-1.658-.753V3.204a1 1 0 0 1 1.659-.753l5.48 4.796a1 1 0 0 1 0 1.506z"/>
-</svg>

--- a/assets/footer.css
+++ b/assets/footer.css
@@ -71,7 +71,7 @@
   
       /* Messages */
       .message-container {
-        padding: 10px;
+        padding: var(--space-lg);
         margin-bottom: 15px;
         text-align: center;
       }
@@ -100,7 +100,7 @@
 
     /* Email Signup */
     .email-signup-section {
-        padding: 20px;
+        padding: var(--space-3xl);
         text-align: center;
         width: 100%;
         box-sizing: border-box;
@@ -129,8 +129,8 @@
    .logo-container {
     width: 100%;
     margin-top: 20px;
-    padding-left: 30px;
-    padding-bottom: 20px;
+    padding-left: var(--space-5xl);
+    padding-bottom: var(--space-3xl);
     order: 2;
     display: flex;
     align-items: flex-start;
@@ -164,12 +164,12 @@
         .mobile-social-icons { display: flex; align-items: center; }
         .custom-gap { gap: calc(var(--spacing) * 5); }
         
-        .email-signup-section { padding: 15px; }
+        .email-signup-section { padding: var(--gutter-sm); }
         .email-input12 { font-size: 28px; height: 50px; line-height: 50px; width: 110%; margin-left: -20px; }
         .signup-button { font-size: 38px; height: 50px; line-height: 50px; width: 110%; margin-left: -20px; justify-content: space-around !important; }
         .arrow-wrapper { width: 60px; height: 40px !important;  }
         
-        .logo-container { padding-left: 35px; padding-bottom: 15px; margin-top: 15px; }
+        .logo-container { padding-left: var(--space-6xl); padding-bottom: var(--gutter-sm); margin-top: 15px; }
         .logo-container img { margin-left: -29px !important; margin-bottom: 8px !important; width: 370px !important; transform: scale(1.0); }
         .logo-container .text-logo { font-size: 35px; transform: scale(1.2); }
         
@@ -182,7 +182,7 @@
         .custom-gap { gap: calc(var(--spacing) * 5); }
         
         .email-signup-section { padding: 18px; }
-        .email-input12 { font-size: 30px; height: 55px; line-height: 55px; width: 115%; margin-left: -25px; padding-left: 10px; }
+        .email-input12 { font-size: 30px; height: 55px; line-height: 55px; width: 115%; margin-left: -25px; padding-left: var(--space-lg); }
         .signup-button { font-size: 38px; height: 55px; line-height: 55px; width: 115%; margin-left: -25px; justify-content: space-around !important; }
         .arrow-wrapper { width: 60px; height: 40px !important; }
         
@@ -200,7 +200,7 @@
   
       @media (min-width: 768px) {
         .custom-mr-25 { margin-right: 25px; }
-        .custom-nav-mr-25 { margin-right: 15px; margin-left: 0; padding-bottom: 10px; }
+        .custom-nav-mr-25 { margin-right: 15px; margin-left: 0; padding-bottom: var(--space-lg); }
         
         .logo-container { width: 60%; margin-top: 0; margin-left: 10px; order: 1; padding-top: 0; }
         .logo-container img { max-width: 570px; height: auto; max-height: 120px; transform: scale(1.12); }
@@ -211,7 +211,7 @@
         .support-social-icons { display: none; }
         .mobile-social-icons { display: flex; align-items: center; }
         
-        .email-signup-section { padding: 25px; }
+        .email-signup-section { padding: var(--gutter-md); }
         .email-input12 { font-size: 36px; height: 70px; line-height: 70px; }
         .signup-button { font-size: 80px; height: 100px; line-height: 70px; }
         .arrow-wrapper { width: 50px; height: 50px !important; }
@@ -220,7 +220,7 @@
       @media (min-width: 1024px) {
         .desktop-ml-15 { margin-left: 15px; }
         .custom-mr-25 { margin-right: 30px; }
-        .custom-nav-mr-25 { margin-right: 20px; padding-bottom: 12px; }
+        .custom-nav-mr-25 { margin-right: 20px; padding-bottom: var(--space-xl); }
         
         .email-input12 { font-size: 110px; height: 120px; line-height: 120px; letter-spacing: -5px; }
         .signup-button { font-size: 100px; height: 120px; line-height: 120px; letter-spacing: -5px; }
@@ -236,7 +236,7 @@
       @media (min-width: 1200px) {
         .desktop-ml-15 { margin-left: 18px; }
         .custom-mr-25 { margin-right: 35px; }
-        .custom-nav-mr-25 { margin-right: 25px; padding-bottom: 15px; }
+        .custom-nav-mr-25 { margin-right: 25px; padding-bottom: var(--space-2xl); }
         
         .logo-container { width: 70%; margin-left: -10px; }
         .logo-container img { max-height: 150px; transform: scale(1.50); margin-left: 70px; }
@@ -301,7 +301,7 @@
   .newsletter-form__message--success,
   .newsletter-form__message--error {
     color: var(--footer-menu-item-color);
-    padding: 15px;
+    padding: var(--space-2xl);
     margin: 10px 0;
     border-radius: var(--inputs-radius);
     background-color: inherit;
@@ -333,7 +333,7 @@
     color: var(--footer-menu-item-color) !important;
     position: relative;
     z-index: var(--z-background-deep);
-    padding: 10px 8px;
+    padding: var(--space-lg) var(--space-md);
     
   }
 

--- a/assets/footer.css
+++ b/assets/footer.css
@@ -30,7 +30,7 @@
         background-position: center;
         background-repeat: no-repeat;
         animation: backgroundMove 10s linear infinite;
-        z-index: -2;
+        z-index: var(--z-background-deep);
       }
       @keyframes backgroundMove {
         0% { background-position: 0% 0%; background-size: 120% 120%; }
@@ -49,7 +49,7 @@
         background: rgba(0, 0, 0, 0.3);
         pointer-events: none;
         animation: grainMove 0.5s linear infinite;
-        z-index: -1;
+        z-index: var(--z-background);
       }
   
       @keyframes grainMove {
@@ -66,7 +66,7 @@
       }
       .footer-content {
         position: relative;
-        z-index: 0;
+        z-index: var(--z-base);
       }
   
       /* Messages */
@@ -332,7 +332,7 @@
     height: 100%;
     color: var(--footer-menu-item-color) !important;
     position: relative;
-    z-index: -2;
+    z-index: var(--z-background-deep);
     padding: 10px 8px;
     
   }
@@ -346,7 +346,7 @@
     height: 100%;
     background: var(--footer-hover-color);
     transition: left 0.5s;
-    z-index: -3;
+    z-index: var(--z-background-deeper);
   }
 
 

--- a/assets/header.css
+++ b/assets/header.css
@@ -281,7 +281,7 @@
     top: 85%;
     left: 0;
     right: 0;
-    z-index: 999;
+    z-index: var(--z-mobile-menu);
     /* Just below header */
     background: var(--header_background);
     overflow: hidden;

--- a/assets/header.css
+++ b/assets/header.css
@@ -132,7 +132,7 @@
         display: flex;
         height: 100vh;
         width: 28px;
-        padding: 15px !important;
+        padding: var(--gutter-sm) !important;
         overflow-x: hidden !important;
         overflow-y: hidden !important;
         border-top: none;
@@ -191,7 +191,7 @@
     width: 100%;
     margin-top: var(--announcement-bar-height);
     background: var(--header_background);
-    padding: 5px var(--sections-side-space);
+    padding: var(--space-xs) var(--sections-side-space);
   }
 
 .search-input:focus {
@@ -373,7 +373,7 @@
     /* smaller text */
     font-weight: inherit;
     /* automatically inherit font weight from parent */
-    padding: 0 6px;
+    padding: 0 var(--space-sm);
     /* less vertical padding */
     line-height: 1;
     /* removes extra height from text */

--- a/assets/icon-custom.svg
+++ b/assets/icon-custom.svg
@@ -1,3 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-caret-right-fill" viewBox="0 0 16 16">
-  <path d="m12.14 8.753-5.482 4.796c-.646.566-1.658.106-1.658-.753V3.204a1 1 0 0 1 1.659-.753l5.48 4.796a1 1 0 0 1 0 1.506z"/>
-</svg>

--- a/assets/icon-email.svg
+++ b/assets/icon-email.svg
@@ -1,3 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-caret-right-fill" viewBox="0 0 16 16">
-  <path d="m12.14 8.753-5.482 4.796c-.646.566-1.658.106-1.658-.753V3.204a1 1 0 0 1 1.659-.753l5.48 4.796a1 1 0 0 1 0 1.506z"/>
-</svg>

--- a/sections/announcement-bar.liquid
+++ b/sections/announcement-bar.liquid
@@ -313,18 +313,7 @@
         {% if section.settings.custom_svg != blank %}
           {{ section.settings.custom_svg }}
         {% else %}
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="16"
-            height="16"
-            fill="var(--text)"
-            viewBox="0 0 16 16"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            class="announcement-svg"
-          >
-            <path d="m12.14 8.753-5.482 4.796c-.646.566-1.658.106-1.658-.753V3.204a1 1 0 0 1 1.659-.753l5.48 4.796a1 1 0 0 1 0 1.506z"/>
-          </svg>
+          {% render 'icon-playback', width: '16px', height: '16px', class: 'announcement-svg', fill: 'var(--text)' %}
         {% endif %}
       {% endunless %}
     </a>

--- a/sections/blog-banner.liquid
+++ b/sections/blog-banner.liquid
@@ -35,16 +35,8 @@
         </p>
         
         <div class="subclass-header1" id="article-title-{{ forloop.index0 }}" style="line-height:var(--t-h-3-line-height); font-size:var(--t-h-3-size); font-weight:var(--t-h-3-weight);">
-          <svg
-            class=" arrow-svgsubw-8 object-contain inline-block"
-            style="height:22px; margin-top:-8px; margin-right:-4px;"
-            viewBox="6 2 8 12"
-            fill="var(--text)"
-            xmlns="http://www.w3.org/2000/svg"
-            stroke="var(--text)"
-            aria-hidden="true">
-            <path d="m12.14 8.753-5.482 4.796c-.646.566-1.658.106-1.658-.753V3.204a1 1 0 0 1 1.659-.753l5.48 4.796a1 1 0 0 1 0 1.506z"/>
-          </svg>
+            {% render 'icon-playback', fill: 'var(--text)', viewBox: '6 2 8 12', class: 'arrow-svgsubw-8 object-contain inline-block',
+               stroke: 'var(--text)', style: 'height:22px; margin-top:-8px; margin-right:-4px;' %}                                
           {{ article.title }}
         </div>
 

--- a/sections/featured-blog.liquid
+++ b/sections/featured-blog.liquid
@@ -758,16 +758,8 @@
                     class="fb-arrow-svg-wrapper object-contain transition-transform duration-300 group-hover:-rotate-90 featured-blog-card-title-arrow inline-block align-baseline"
                     alt="Dropdown Icon"
                   >
-                    <svg
-                      class="fb-arrow-svg w-5 h-5 object-contain transition-transform duration-200 ease-in-out group-hover:-rotate-90 mx-1"
-                      viewBox="4.5 1.5 8.5 13"
-                      fill="currentColor"
-                      xmlns="http://www.w3.org/2000/svg"
-                      stroke="currentColor"
-                      aria-hidden="true"
-                    >
-                      <path d="m12.14 8.753-5.482 4.796c-.646.566-1.658.106-1.658-.753V3.204a1 1 0 0 1 1.659-.753l5.48 4.796a1 1 0 0 1 0 1.506z"/>
-                    </svg>
+                    {% render 'icon-playback', width: 20, height: 20, fill: 'currentColor', viewBox: '4.5 1.5 8.5 13', class: 'fb-arrow-svg w-5 h-5 object-contain transition-transform duration-200 ease-in-out group-hover:-rotate-90 mx-1',
+                    stroke: 'currentColor' %}     
                   </div>
                   {% comment %}
                     <img

--- a/sections/featured-collection.liquid
+++ b/sections/featured-collection.liquid
@@ -154,19 +154,8 @@
                     <path d="M1.1875 7.7334H7.6599M7.6599 7.7334V1.261M7.6599 7.7334L1.1875 1.261"/>
                   </svg>
                 {% endcomment %}
-                <svg
-                  width="18"
-                  height="16"
-                  viewBox="4.5 1.5 8.5 13"
-                  fill="none"
-                  xmlns="http://www.w3.org/2000/svg"
-                  style="width: 18px; height: 16px;"
-                  class="featured-collection-arrow-svg object-contain transition-transform duration-300 ease-in-out mx-1 featured-collection-play"
-                  stroke="currentColor"
-                >
-                  <path d="m12.14 8.753-5.482 4.796c-.646.566-1.658.106-1.658-.753V3.204a1 1 0 0 1 1.659-.753l5.48 4.796a1 1 0 0 1 0 1.506z"/>
-                </svg>
-
+                {% render 'icon-playback', width: 18, height: 16, fill: 'none', viewBox: '4.5 1.5 8.5 13', class: 'featured-collection-arrow-svg object-contain transition-transform duration-300 ease-in-out mx-1 featured-collection-play',
+                stroke: 'currentColor', style: 'width: 18px; height: 16px;' %}     
                 {% comment %}
                   <svg
                     class="featured-collection-arrow-svg transition-transform duration-200 ease-in-out"

--- a/sections/footer.liquid
+++ b/sections/footer.liquid
@@ -107,10 +107,7 @@
 
   {{ block.settings.email_link_text }}
 
-  {{ 'icon-email.svg'
-     | inline_asset_content
-     | replace: '<svg', '<svg class="email-icon" role="img" aria-hidden="true" style="height: 20px; fill: '
-     | remove: "'" }}
+     {% render 'icon-playback', width: '20px', height: '20px', class: 'email-icon' %}
 </a>
 
 

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -167,13 +167,7 @@
                                       
                                         {{ block.settings.button_text_1 }}
                                       </p>
-                                     {{
-  'icon-custom.svg'
-  | inline_asset_content
-  | replace: '<svg', '<svg role="img" aria-hidden="true" style="height: 20px; width: 20px; fill: '
-  | append: settings.social_icon_color
-  | remove: "'"
-}}
+                                      {% render 'icon-playback', width: 20, height: 20, fill: settings.social_icon_color %}                                   
                                     </div>
                                   {% endif %}
                                 </a>
@@ -214,13 +208,7 @@
                                       >
                                         {{ block.settings.button_text_2 }}
                                       </p>
-                                                                           {{
-  'icon-custom.svg'
-  | inline_asset_content
-  | replace: '<svg', '<svg role="img" aria-hidden="true" style="height: 20px; width: 20px; fill: '
-  | append: settings.social_icon_color
-  | remove: "'"
-}}
+                                      {% render 'icon-playback', width: 20, height: 20, fill: settings.social_icon_color %}                                
                                     </div>
                                   {% endif %}
                                 </a>
@@ -260,13 +248,7 @@
                               width="100%"
                             >
                           {% else %}
-                          <img
-                          class="scrolling-separator"
-                          src="{{ 'caret-right-fill2.svg' | asset_url }}"
-                          alt="separator"
-                          height="100%"
-                          width="100%"
-                        >
+                          {% render 'icon-playback', class: 'bi bi-caret-right-fill scrolling-separator', width: '16px', height: '16px', fill: "currentColor" %}
                           {% endif %}
                         {% endfor %}
                         <!-- Duplicate set for seamless infinite scrolling -->
@@ -550,13 +532,7 @@ style="border-top: 1px solid rgb(var(--color-foreground)); border-bottom: 1px so
           width="100%"
         >
         {% else %}
-        <img
-        class="scrolling-separator"
-        src="{{ 'caret-right-fill2.svg' | asset_url }}"
-        alt="separator"
-        height="100%"
-        width="100%"
-      >
+        {% render 'icon-playback', class: 'bi bi-caret-right-fill scrolling-separator', width: '16px', height: '16px', fill: "currentColor" %}
         {% endif %}
       {% endfor %}
       <!-- Duplicate set for seamless infinite scrolling -->
@@ -572,13 +548,7 @@ style="border-top: 1px solid rgb(var(--color-foreground)); border-bottom: 1px so
               width="100%"
             >
             {% else %}
-            <img
-            class="scrolling-separator"
-            src="{{ 'caret-right-fill2.svg' | asset_url }}"
-            alt="separator"
-            height="100%"
-            width="100%"
-          >
+            {% render 'icon-playback', class: 'bi bi-caret-right-fill scrolling-separator', width: '16px', height: '16px', fill: "currentColor" %}
             {% endif %}
         {% endunless %}
       {% endfor %}
@@ -801,9 +771,7 @@ style="border-top: 1px solid rgb(var(--color-foreground)); border-bottom: 1px so
             <span class="" style="color: var(--header_text);">
               {{ current_country.name | upcase }}
             </span>
-            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-caret-right-fill" viewBox="0 0 16 16">
-            <path d="m12.14 8.753-5.482 4.796c-.646.566-1.658.106-1.658-.753V3.204a1 1 0 0 1 1.659-.753l5.48 4.796a1 1 0 0 1 0 1.506z"/>
-          </svg>
+            {% render 'icon-playback', class: 'bi bi-caret-right-fill scrolling-separator', width: '16px', height: '16px', fill: "currentColor" %}
           </button>
 
           <!-- Dropdown -->

--- a/sections/main-article.liquid
+++ b/sections/main-article.liquid
@@ -57,21 +57,8 @@
     </div>
 
    <div class="maintext flex flex-row" style="margin-top:50px;font-size:2.6vh;">
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        class="arrow-svg12"
-        viewBox="0 0 15 15"
-        stroke-width="1.5"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        style="fill:var(--text);
-        margin-top:1px;
-  height: 23px ;
-  width: 30px;"
-      >
-         <path d="m12.14 8.753-5.482 4.796c-.646.566-1.658.106-1.658-.753V3.204a1 1 0 0 1 1.659-.753l5.48 4.796a1 1 0 0 1 0 1.506z"/>
-      </svg>
-
+      {% render 'icon-playback', viewBox: '0 0 15 15', class: 'arrow-svg12',
+      stroke-width: '1.5', stroke-linecap: "round", stroke-linejoin: "round",  style: 'fill:var(--text); margin-top:1px; height: 23px ; width: 30px;' %}    
       <div
   class="blog-article-section color-{{ section.settings.color_scheme }}"
   style="font-family: var(--font-body-family);margin-left: auto; margin-right: auto; font-size:var(--t-b-2-size); font-weight:var(--t-b-2-weight); line-height:var(--t-b-2-line-height);width:1000px;"
@@ -151,17 +138,8 @@
                   {{ article.published_at | date: "%m.%d.%y" }}
                 </p>
                 <div class="subclass-header" id="article-title-{{ forloop.index0 }}" style="font-family: var(--font-heading-family);font-size:var(--t-h-4-size); font-weight:var(--t-h-4-weight); line-height:var(--t-h-4-line-height);">
-                   <svg
-                      class=" arrow-svgsubw-8 object-contain inline-block"
-                      style="height:22px; margin-top:-8px; margin-right:-4px;"
-                      viewBox="5.5 2 8.5 13"
-                      fill="var(--text)"
-                      xmlns="http://www.w3.org/2000/svg"
-                      stroke="var(--text)"
-                      aria-hidden="true"
-                    >
-                      <path d="m12.14 8.753-5.482 4.796c-.646.566-1.658.106-1.658-.753V3.204a1 1 0 0 1 1.659-.753l5.48 4.796a1 1 0 0 1 0 1.506z"/>
-                    </svg>
+                    {% render 'icon-playback', fill: 'var(--text)', viewBox: '5.5 2 8.5 13', class: 'arrow-svgsubw-8 object-contain inline-block',
+                    stroke: 'var(--text)', style: 'height:22px; margin-top:-8px; margin-right:-4px;' %}                       
                   {{ article.title }}
                   </div>
                 <span class="subclass-subheader text-[20px] tracking-tight" style="font-family: var(--font-body-family);font-size:var(--t-b-2-size); font-weight:var(--t-b-2-weight); line-height:var(--t-b-2-line-height);">

--- a/sections/outfit_inspiration.liquid
+++ b/sections/outfit_inspiration.liquid
@@ -142,16 +142,7 @@
                                 data-product-id="{{ paired_product.id }}"
                                 data-section-id="{{ section.id }}"
                               >
-                                <svg
-                                  xmlns="http://www.w3.org/2000/svg"
-                                  width="16"
-                                  height="16"
-                                  fill="currentColor"
-                                  class="bi bi-caret-right-fill outfit-expand-product-btn-svg "
-                                  viewBox="0 0 16 16"
-                                >
-                                  <path d="m12.14 8.753-5.482 4.796c-.646.566-1.658.106-1.658-.753V3.204a1 1 0 0 1 1.659-.753l5.48 4.796a1 1 0 0 1 0 1.506z"/>
-                                </svg>
+                                {% render 'icon-playback', class: 'bi bi-caret-right-fill outfit-expand-product-btn-svg', width: '16', height: '16', fill: "currentColor" %}
                               </button>
                             </div>
                           </div>
@@ -192,17 +183,7 @@
                                     data-product-id="{{ paired_product.id }}"
                                     data-section-id="{{ section.id }}"
                                   >
-                                    <svg
-                                      xmlns="http://www.w3.org/2000/svg"
-                                      width="16"
-                                      height="16"
-                                      fill="currentColor"
-                                      class="bi bi-caret-right-fill"
-                                      viewBox="0 0 16 16"
-                                      style="transform: rotate(90deg);"
-                                    >
-                                      <path d="m12.14 8.753-5.482 4.796c-.646.566-1.658.106-1.658-.753V3.204a1 1 0 0 1 1.659-.753l5.48 4.796a1 1 0 0 1 0 1.506z"/>
-                                    </svg>
+                                  {% render 'icon-playback', class: 'bi bi-caret-right-fill', width: '16', height: '16', fill: "currentColor", style: "transform: rotate(90deg);" %}
                                   </button>
                                 </div>
 

--- a/sections/scrolling-marquee.liquid
+++ b/sections/scrolling-marquee.liquid
@@ -97,17 +97,8 @@
       class="inline-block ml-1"
     />
   {% else %}
-    <svg
-      class="inline-block ml-1 transition-transform duration-200 ease-in-out"
-      style="height: {{ icon_height }}px; width: {{ icon_width }}px;"
-      viewBox="4.5 1.5 8.5 13"
-      fill="currentColor"
-      xmlns="http://www.w3.org/2000/svg"
-      stroke="currentColor"
-      aria-hidden="true"
-    >
-      <path d="m12.14 8.753-5.482 4.796c-.646.566-1.658.106-1.658-.753V3.204a1 1 0 0 1 1.659-.753l5.48 4.796a1 1 0 0 1 0 1.506z"/>
-    </svg>
+    {% render 'icon-playback', fill: 'currentColor', viewBox: '4.5 1.5 8.5 13', class: 'inline-block ml-1 transition-transform duration-200 ease-in-out',
+    stroke: 'currentColor', style: 'height: {{ icon_height }}px; width: {{ icon_width }}px;' %}  
   {% endif %}
 {% endcapture %}
 

--- a/snippets/article-card.liquid
+++ b/snippets/article-card.liquid
@@ -30,15 +30,8 @@
             {{ article.published_at | date: "%m.%d.%y" }}
           </p>
           <div class="subclass-header" id="article-title-{{ forloop.index0 }}" style="font-family: var(--font-heading-family);font-size:var(--t-h-4-size); font-weight:var(--t-h-4-weight); line-height:var(--t-h-4-line-height);">
-            <svg class="w-8 object-contain inline-block"
-                 style="height:22px; margin-top:-8px; margin-right:-4px;"
-                 viewBox="5.5 2 8.5 13"
-                 fill="currentColor"
-                 xmlns="http://www.w3.org/2000/svg"
-                 stroke="currentColor"
-                 aria-hidden="true">
-              <path d="m12.14 8.753-5.482 4.796c-.646.566-1.658.106-1.658-.753V3.204a1 1 0 0 1 1.659-.753l5.48 4.796a1 1 0 0 1 0 1.506z"/>
-            </svg>
+            {% render 'icon-playback', fill: 'currentColor', viewBox: '5.5 2 8.5 13', class: 'w-8 object-contain inline-block',
+            stroke: 'currentColor', style: 'height:22px; margin-top:-8px; margin-right:-4px;' %}   
             {{ article.title }}
           </div>
           <span class="subclass-subheader font-medium tracking-tight" style="font-family: var(--font-body-family);font-size:var(--t-b-2-size); font-weight:var(--t-b-2-weight); line-height:var(--t-b-2-line-height);">

--- a/snippets/icon-playback.liquid
+++ b/snippets/icon-playback.liquid
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="{{width}}" height="{{height}}" fill="currentColor" class="{{ class }}" viewBox="{{ viewBox| default: '0 0 16 16' }}"  style="{{style}}", stroke="{{stroke}}",
+stroke-width= "{{stroke-width}}", stroke-linecap="{{stroke-linecap}}", stroke-linejoin="{{stroke-linejoin}}">
+  <path d="m12.14 8.753-5.482 4.796c-.646.566-1.658.106-1.658-.753V3.204a1 1 0 0 1 1.659-.753l5.48 4.796a1 1 0 0 1 0 1.506z"/>
+</svg>

--- a/snippets/primary-button.liquid
+++ b/snippets/primary-button.liquid
@@ -183,16 +183,7 @@
       >
         {{ button_text | escape }}
         <span class="primary-slide-button-arrow" aria-hidden="true">
-          <svg
-            width="16"
-            height="16"
-            viewBox="4.5 1.5 8.5 13"
-            fill="currentColor"
-            xmlns="http://www.w3.org/2000/svg"
-            stroke="currentColor"
-          >
-            <path d="m12.14 8.753-5.482 4.796c-.646.566-1.658.106-1.658-.753V3.204a1 1 0 0 1 1.659-.753l5.48 4.796a1 1 0 0 1 0 1.506z"/>
-          </svg>
+          {% render 'icon-playback', width: '16', height: '16', viewBox: '4.5 1.5 8.5 13', stoke: 'currentColor' %}
         </span>
       </div>
       <div
@@ -201,16 +192,7 @@
       >
         {{ button_text | escape }}
         <span class="primary-slide-button-arrow" aria-hidden="true">
-          <svg
-            width="16"
-            height="16"
-            viewBox="4.5 1.5 8.5 13"
-            fill="currentColor"
-            xmlns="http://www.w3.org/2000/svg"
-            stroke="currentColor"
-          >
-            <path d="m12.14 8.753-5.482 4.796c-.646.566-1.658.106-1.658-.753V3.204a1 1 0 0 1 1.659-.753l5.48 4.796a1 1 0 0 1 0 1.506z"/>
-          </svg>
+          {% render 'icon-playback', width: '16', height: '16', viewBox: '4.5 1.5 8.5 13', stoke: 'currentColor', fill: 'currentColor' %}
         </span>
       </div>
     </div>
@@ -229,16 +211,7 @@
       >
         {{ button_text | escape }}
         <span class="primary-slide-button-arrow" aria-hidden="true">
-          <svg
-            width="16"
-            height="16"
-            viewBox="4.5 1.5 8.5 13"
-            fill="currentColor"
-            xmlns="http://www.w3.org/2000/svg"
-            stroke="currentColor"
-          >
-            <path d="m12.14 8.753-5.482 4.796c-.646.566-1.658.106-1.658-.753V3.204a1 1 0 0 1 1.659-.753l5.48 4.796a1 1 0 0 1 0 1.506z"/>
-          </svg>
+          {% render 'icon-playback', width: '16', height: '16px', viewBox: '4.5 1.5 8.5 13', stoke: 'currentColor', fill: 'currentColor' %}
         </span>
       </div>
       <div
@@ -247,16 +220,7 @@
       >
         {{ button_text | escape }}
         <span class="primary-slide-button-arrow" aria-hidden="true">
-          <svg
-            width="16"
-            height="16"
-            viewBox="4.5 1.5 8.5 13"
-            fill="currentColor"
-            xmlns="http://www.w3.org/2000/svg"
-            stroke="currentColor"
-          >
-            <path d="m12.14 8.753-5.482 4.796c-.646.566-1.658.106-1.658-.753V3.204a1 1 0 0 1 1.659-.753l5.48 4.796a1 1 0 0 1 0 1.506z"/>
-          </svg>
+          {% render 'icon-playback', width: '16', height: '16', viewBox: '4.5 1.5 8.5 13', stoke: 'currentColor', fill: 'currentColor' %}
         </span>
       </div>
     </div>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Centralizes the playback/caret icon via a new `snippets/icon-playback` and replaces inline/asset SVGs across the theme, while aligning header/footer CSS to design tokens (spacing/z-index).
> 
> - **Icons**:
>   - Add reusable `snippets/icon-playback.liquid` and replace inline/asset SVGs with `{% render 'icon-playback' %}` in `sections/*` (announcement bar, blog banner, featured blog/collection, header, main-article, outfit_inspiration, scrolling-marquee) and `snippets/*` (article-card, primary-button).
>   - Remove/stop using asset SVGs like `assets/icon-custom.svg`, `assets/icon-email.svg`, and `assets/caret-right-fill2.svg` in favor of the snippet.
> - **Header/Footer CSS**:
>   - Update `assets/header.css` and `assets/footer.css` to use spacing/z-index design tokens (e.g., `var(--gutter-*)`, `var(--space-*)`, `var(--z-*)`), and minor padding adjustments.
>   - Set context-aware z-indexes (e.g., mega menu `z-index: var(--z-mobile-menu)`), cart bracket and header/footer paddings to tokenized values.
> - **Footer markup**:
>   - Replace email icon inline asset with `icon-playback`; adjust newsletter message and signup button z-index/padding and background layers.
> - **Misc**:
>   - Swap header scrolling separators and country selector icons to `icon-playback`; standardize arrow/playback icons across buttons and lists.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 33a5aac5bab809faa7e10f617f459f8e3b780d4b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->