### PR TITLE
added color custom

### DIFF
--- a/assets/email-signup-banner.css
+++ b/assets/email-signup-banner.css
@@ -12,7 +12,7 @@
 }
 
 .signup-with-email {
-  background: #f2f2f2;
+  background: var(--background-box-color, #8A5E46);
   margin: auto;
   height: 80vh;
   width: 80vw;

--- a/sections/email-signup-banner.liquid
+++ b/sections/email-signup-banner.liquid
@@ -10,6 +10,7 @@
     --subscribe-hover-bg: {{ section.settings.subscribe_hover_background | default: color_scheme.settings.background }};
     --subscribe-hover-text: {{ section.settings.subscribe_hover_text_color | default: color_scheme.settings.text }};
     --slide-duration: {{ section.settings.slide_animation_duration | default: 0.4 }}s;
+    --background-box-color: {{ section.settings.background_color | default: '#8A5E46' }};
   }
 
   .pass-subscribe::before {
@@ -24,6 +25,10 @@
   .pass-subscribe:hover {
     color: var(--subscribe-hover-text);
   }
+
+  .signup-with-email {
+    background: var(--background-box-color);
+  }
 </style>
 
 <div
@@ -33,100 +38,98 @@
   role="main"
   aria-label="Password protected store"
 >
-<div class="flex items-center justify-between signup-with-email">
-  <div
-    class="flex flex-col md:flex-column items-center justify-between gap-6 md:gap-20 w-full max-w-[800px]"
-    id="mainContainer-password"
-    role="region"
-    aria-labelledby="email-signup-subheading"
-  >
-    <!-- Text content with fixed width to prevent affecting layout -->
+  <div class="flex items-center justify-between signup-with-email">
     <div
-      class="pass-container ml-10 md:w-[30%] lg:ml-0 flex-shrink-0 space-y-0 text-left px-4 md:pl-20"
-      role="complementary"
-      aria-label="Email signup information"
+      class="flex flex-col md:flex-column items-center justify-between gap-6 md:gap-20 w-full max-w-[800px]"
+      id="mainContainer-password"
+      role="region"
+      aria-labelledby="email-signup-subheading"
     >
-      <p
-        class="pass-heading1 m-0 leading-none break-words w-full flex justify-center md:block md:justify-start whitespace-nowrap truncate"
-        role="heading"
-        aria-level="1"
-      >
-        {{ section.settings.heading_1 }}
-      </p>
-      <p
-        class="pass-heading2 m-0 leading-none break-words w-full flex justify-center md:block md:justify-start whitespace-nowrap truncate"
-        role="heading"
-        aria-level="2"
-      >
-        {{ section.settings.heading_2 }}
-      </p>
-      <h2
-        class="pass-subheading font-light m-0 uppercase mt-6 tracking-tight leading-none break-words block justify-center md:block md:justify-start text-wrap"
-        id="email-signup-subheading"
-      >
-        {{ section.settings.subheading }}
-      </h2>
-    </div>
-
-    <!-- Form Container with fixed width -->
-    <div
-      id="formContainer-password"
-      class="w-full md:w-[60%] flex flex-col items-end lg:mr-0 px-4"
-      role="form"
-      style="font-size: 12px;"
-      aria-label="Email signup form"
-    >
-      {% render 'email-signup-form',
-        button_text: section.settings.button_text,
-        placeholder: section.settings.modal_placeholder,
-      %}
-
+      <!-- Text content with fixed width to prevent affecting layout -->
       <div
-        class="bb-enter-pwd-signup flex flex-col items-center justify-center w-full mt-6 md:flex-row md:justify-center md:w-[40%]"
-        role="navigation"
-        aria-label="Password access"
+        class="pass-container ml-10 md:w-[30%] lg:ml-0 flex-shrink-0 space-y-0 text-left px-4 md:pl-20"
+        role="complementary"
+        aria-label="Email signup information"
       >
-        <span
-          class="pass-text1 text-[20px] sm:text-[16px] mr-4 mb-0 md:mt-0 cursor-pointer"
-          role="text"
-          aria-label="{{ section.settings.password_text_1 }}"
+        <p
+          class="pass-heading1 m-0 leading-none break-words w-full flex justify-center md:block md:justify-start whitespace-nowrap truncate"
+          role="heading"
+          aria-level="1"
         >
-          {{ section.settings.password_text_1 }}
-        </span>
-        <button
-          type="button"
-          onclick="loadPasswordSection()"
-          class="bb-enter-pwd-button inline-flex items-center cursor-pointer text-[16px] tracking-tight px-6 py-0 md:ml-6 rounded-md transition-colors focus:outline-none focus:ring-1"
-          id="enterPasswordBtn"
-          aria-label="Enter password to access the store"
-          aria-expanded="false"
-          aria-controls="password-modal"
-          aria-haspopup="dialog"
+          {{ section.settings.heading_1 }}
+        </p>
+        <p
+          class="pass-heading2 m-0 leading-none break-words w-full flex justify-center md:block md:justify-start whitespace-nowrap truncate"
+          role="heading"
+          aria-level="2"
         >
-          <div class="pass-text-container">
-            <div class="pass-text">
-              <span class="sr-only">Click to </span>{{ section.settings.password_text_2 }}
+          {{ section.settings.heading_2 }}
+        </p>
+        <h2
+          class="pass-subheading font-light m-0 uppercase mt-6 tracking-tight leading-none break-words block justify-center md:block md:justify-start text-wrap"
+          id="email-signup-subheading"
+        >
+          {{ section.settings.subheading }}
+        </h2>
+      </div>
+
+      <!-- Form Container with fixed width -->
+      <div
+        id="formContainer-password"
+        class="w-full md:w-[60%] flex flex-col items-end lg:mr-0 px-4"
+        role="form"
+        style="font-size: 12px;"
+        aria-label="Email signup form"
+      >
+        {% render 'email-signup-form',
+          button_text: section.settings.button_text,
+          placeholder: section.settings.modal_placeholder
+        %}
+
+        <div
+          class="bb-enter-pwd-signup flex flex-col items-center justify-center w-full mt-6 md:flex-row md:justify-center md:w-[40%]"
+          role="navigation"
+          aria-label="Password access"
+        >
+          <span
+            class="pass-text1 text-[20px] sm:text-[16px] mr-4 mb-0 md:mt-0 cursor-pointer"
+            role="text"
+            aria-label="{{ section.settings.password_text_1 }}"
+          >
+            {{ section.settings.password_text_1 }}
+          </span>
+          <button
+            type="button"
+            onclick="loadPasswordSection()"
+            class="bb-enter-pwd-button inline-flex items-center cursor-pointer text-[16px] tracking-tight px-6 py-0 md:ml-6 rounded-md transition-colors focus:outline-none focus:ring-1"
+            id="enterPasswordBtn"
+            aria-label="Enter password to access the store"
+            aria-expanded="false"
+            aria-controls="password-modal"
+            aria-haspopup="dialog"
+          >
+            <div class="pass-text-container">
+              <div class="pass-text"><span class="sr-only">Click to </span>{{ section.settings.password_text_2 }}</div>
+              <div class="pass-text-hover">
+                <svg
+                  class="w-8 h-8 mr-4"
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="currentColor"
+                  viewBox="0 0 254 254"
+                  stroke="currentColor"
+                  aria-hidden="true"
+                  role="img"
+                  aria-label="Password icon"
+                >
+                  <path stroke-linecap="round" d="M208,80H176V56a48,48,0,0,0-96,0V80H48A16,16,0,0,0,32,96V208a16,16,0,0,0,16,16H208a16,16,0,0,0,16-16V96A16,16,0,0,0,208,80ZM96,56a32,32,0,0,1,64,0V80H96ZM208,208H48V96H208V208Zm-68-56a12,12,0,1,1-12-12A12,12,0,0,1,140,152Z"/>
+                </svg>
+                <span class="sr-only">Click to </span>{{ section.settings.password_text_2 }}
+              </div>
             </div>
-            <div class="pass-text-hover">
-               <svg
-                class="w-8 h-8 mr-4"
-                xmlns="http://www.w3.org/2000/svg"
-                fill="currentColor"
-                viewBox="0 0 254 254"
-                stroke="currentColor"
-                aria-hidden="true"
-                role="img"
-                aria-label="Password icon"
-              >
-               <path stroke-linecap="round" d="M208,80H176V56a48,48,0,0,0-96,0V80H48A16,16,0,0,0,32,96V208a16,16,0,0,0,16,16H208a16,16,0,0,0,16-16V96A16,16,0,0,0,208,80ZM96,56a32,32,0,0,1,64,0V80H96ZM208,208H48V96H208V208Zm-68-56a12,12,0,1,1-12-12A12,12,0,0,1,140,152Z"/>
-              </svg>
-              <span class="sr-only">Click to </span>{{ section.settings.password_text_2 }}
-            </div>
-          </div>
-        </button>
+          </button>
+        </div>
       </div>
     </div>
-  </div>
   </div>
 </div>
 
@@ -159,7 +162,7 @@
       "label": "t:sections.password_page.settings.heading_1",
       "default": "GOOD THINGS TAKE TIME"
     },
-    { 
+    {
       "type": "text",
       "id": "heading_2",
       "label": "t:sections.password_page.settings.heading_2"
@@ -266,6 +269,17 @@
       "step": 4,
       "unit": "px",
       "default": 0
+    },
+    {
+      "type": "header",
+      "content": "Background Customization"
+    },
+    {
+      "type": "color",
+      "id": "background_color",
+      "label": "Background Box Color",
+      "info": "Customize the background color of the main content box",
+      "default": "#8A5E46"
     }
   ],
   "blocks": [


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a new `background_color` setting and CSS var to control `.signup-with-email` background, replacing the hardcoded color.
> 
> - **Theme customization**:
>   - Introduces `section.settings.background_color` with default `#8A5E46` and exposes it as `--background-box-color`.
>   - Applies `--background-box-color` to `.signup-with-email` (replacing hardcoded `#f2f2f2`).
> - **Styles**:
>   - Adds inline style hook for `.signup-with-email` in `sections/email-signup-banner.liquid` and fallback usage in `assets/email-signup-banner.css`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 85450909651cec90ec1fb043734906018697555e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->