### PR TITLE
csp issues resolved

### DIFF
--- a/assets/cart-drawer-custom.js
+++ b/assets/cart-drawer-custom.js
@@ -349,6 +349,32 @@ function initializeCartDrawer() {
     window.cartDrawerObserver = observer;
   }
 
+  // ===================================================================
+  // CART DRAWER CLOSE BUTTONS (CSP-compliant event listeners)
+  // ===================================================================
+
+  // Add event listeners for close buttons
+  const closeButtons = document.querySelectorAll('.drawer__close, .drawer__close2');
+  closeButtons.forEach(function (button) {
+    button.addEventListener('click', function () {
+      const cartDrawer = this.closest('cart-drawer');
+      if (cartDrawer && typeof cartDrawer.close === 'function') {
+        cartDrawer.close();
+      }
+    });
+
+    // Add keyboard accessibility
+    button.addEventListener('keydown', function (e) {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        const cartDrawer = this.closest('cart-drawer');
+        if (cartDrawer && typeof cartDrawer.close === 'function') {
+          cartDrawer.close();
+        }
+      }
+    });
+  });
+
   // Add event listeners for size and color changes
   document.addEventListener('click', function (e) {
     if (e.target.classList.contains('size-option')) {
@@ -369,6 +395,8 @@ function initializeCartDrawer() {
       }
     }
   });
+
+  console.log('✅ Cart drawer event listeners initialized (CSP-compliant)');
 }
 
 // Initialize when DOM is loaded

--- a/assets/email-signup.js
+++ b/assets/email-signup.js
@@ -15,16 +15,67 @@ document.addEventListener('DOMContentLoaded', function () {
 
   let isSubmitting = false;
 
-  // Password modal functionality
-  enterPasswordBtn.onclick = function () {
-    passwordModal.classList.remove('hidden');
-    mainContainer.style.display = 'none';
-  };
+  // ===================================================================
+  // PASSWORD MODAL FUNCTIONALITY (CSP-compliant with event listeners)
+  // ===================================================================
 
-  closeModalBtn.onclick = function () {
-    passwordModal.classList.add('hidden');
-    mainContainer.style.display = 'flex';
-  };
+  // Function to open password modal
+  function openPasswordModal() {
+    if (passwordModal && mainContainer) {
+      passwordModal.classList.remove('hidden');
+      mainContainer.style.display = 'none';
+
+      // Update ARIA attribute
+      if (enterPasswordBtn) {
+        enterPasswordBtn.setAttribute('aria-expanded', 'true');
+      }
+
+      // Focus on password input for better UX
+      const passwordInput = passwordModal.querySelector('input[type="password"]');
+      if (passwordInput) {
+        setTimeout(() => passwordInput.focus(), 100);
+      }
+    }
+  }
+
+  // Function to close password modal
+  function closePasswordModal() {
+    if (passwordModal && mainContainer) {
+      passwordModal.classList.add('hidden');
+      mainContainer.style.display = 'flex';
+
+      // Update ARIA attribute
+      if (enterPasswordBtn) {
+        enterPasswordBtn.setAttribute('aria-expanded', 'false');
+      }
+    }
+  }
+
+  // Add click event listener to password button
+  if (enterPasswordBtn) {
+    enterPasswordBtn.addEventListener('click', openPasswordModal);
+
+    // Add keyboard accessibility
+    enterPasswordBtn.addEventListener('keydown', function (e) {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        openPasswordModal();
+      }
+    });
+  }
+
+  // Add click event listener to close button
+  if (closeModalBtn) {
+    closeModalBtn.addEventListener('click', closePasswordModal);
+
+    // Add keyboard accessibility
+    closeModalBtn.addEventListener('keydown', function (e) {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        closePasswordModal();
+      }
+    });
+  }
 
   // Email validation functionality
   function validateEmail() {
@@ -77,7 +128,6 @@ document.addEventListener('DOMContentLoaded', function () {
       submitButton.disabled = true;
 
       await new Promise((resolve) => setTimeout(resolve, 9000));
-
     } catch (error) {
       buttonText.textContent = 'SUBSCRIBE';
       loadingSpinner.classList.add('hidden');
@@ -89,4 +139,7 @@ document.addEventListener('DOMContentLoaded', function () {
       isSubmitting = false;
     }
   });
+
+  // Log successful initialization
+  console.log('✅ Email signup and password modal event listeners initialized (CSP-compliant)');
 });

--- a/assets/main-cart-items.js
+++ b/assets/main-cart-items.js
@@ -16,6 +16,10 @@ function toggleSection(header) {
     s.classList.remove('expanded');
     const icon = s.querySelector('.pmorph__icon');
     if (icon) icon.classList.remove('expanded');
+
+    // Update aria-expanded for all headers
+    const sectionHeader = s.querySelector('.sidebar-header');
+    if (sectionHeader) sectionHeader.setAttribute('aria-expanded', 'false');
   });
 
   // Open clicked section and animate icon
@@ -23,6 +27,9 @@ function toggleSection(header) {
     section.classList.add('expanded');
     const icon = section.querySelector('.pmorph__icon');
     if (icon) icon.classList.add('expanded');
+
+    // Update aria-expanded for the opened section
+    header.setAttribute('aria-expanded', 'true');
   }
 }
 
@@ -709,4 +716,54 @@ document.addEventListener('DOMContentLoaded', function () {
     },
     true
   );
+
+  // ===================================================================
+  // COLOR PICKER EVENT LISTENERS (replaces inline onclick handlers)
+  // ===================================================================
+
+  // Attach click handlers to all color pickers
+  const colorPickers = document.querySelectorAll('.color-picker');
+
+  colorPickers.forEach(function (picker) {
+    picker.addEventListener('click', function () {
+      changeItemColor(this);
+    });
+
+    // Add keyboard accessibility
+    picker.setAttribute('role', 'button');
+    picker.setAttribute('tabindex', '0');
+
+    picker.addEventListener('keydown', function (e) {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        changeItemColor(this);
+      }
+    });
+  });
+
+  // ===================================================================
+  // SIDEBAR SECTION TOGGLE EVENT LISTENERS (replaces inline onclick)
+  // ===================================================================
+
+  const sidebarHeaders = document.querySelectorAll('.sidebar-header');
+
+  sidebarHeaders.forEach(function (header) {
+    header.addEventListener('click', function () {
+      toggleSection(this);
+    });
+
+    // Add keyboard accessibility
+    header.setAttribute('role', 'button');
+    header.setAttribute('tabindex', '0');
+    header.setAttribute('aria-expanded', 'false');
+
+    header.addEventListener('keydown', function (e) {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        toggleSection(this);
+      }
+    });
+  });
+
+  console.log('✅ Cart event listeners initialized (CSP-compliant)');
 });

--- a/sections/email-signup-banner.liquid
+++ b/sections/email-signup-banner.liquid
@@ -100,7 +100,6 @@
           </span>
           <button
             type="button"
-            onclick="loadPasswordSection()"
             class="bb-enter-pwd-button inline-flex items-center cursor-pointer text-[16px] tracking-tight px-6 py-0 md:ml-6 rounded-md transition-colors focus:outline-none focus:ring-1"
             id="enterPasswordBtn"
             aria-label="Enter password to access the store"

--- a/sections/main-cart-items.liquid
+++ b/sections/main-cart-items.liquid
@@ -100,7 +100,6 @@
                             data-item-key="{{ item.key }}"
                             data-current-size="{{ size_option.value | default: '' }}"
                             title="{{ current_color }}"
-                            onclick="changeItemColor(this)"
                           ></div>
                         {% else %}
                           <div
@@ -110,7 +109,6 @@
                             data-item-key="{{ item.key }}"
                             data-current-size="{{ size_option.value | default: '' }}"
                             title="{{ current_color }}"
-                            onclick="changeItemColor(this)"
                             style="background: {{ current_color | downcase }} !important;"
                           ></div>
                         {% endif %}
@@ -193,7 +191,6 @@
                                     data-item-key="{{ item.key }}"
                                     data-current-size="{{ size_option.value | default: '' }}"
                                     title="{{ variant_color }}"
-                                    onclick="changeItemColor(this)"
                                   ></div>
                                 {% else %}
                                   <div
@@ -203,7 +200,6 @@
                                     data-item-key="{{ item.key }}"
                                     data-current-size="{{ size_option.value | default: '' }}"
                                     title="{{ variant_color }}"
-                                    onclick="changeItemColor(this)"
                                     style="background: {{ variant_color | downcase }} !important;"
                                   ></div>
                                 {% endif %}
@@ -248,7 +244,7 @@
     <div class="cart-sidebar">
       <div class="sidebar-sections">
         <div class="sidebar-section">
-          <div class="sidebar-header" onclick="toggleSection(this)">
+          <div class="sidebar-header">
             <span class="sidebar-title"
               >Add a Note to<br>
               Your Order:</span
@@ -264,7 +260,7 @@
         </div>
 
         <div class="sidebar-section">
-          <div class="sidebar-header" onclick="toggleSection(this)">
+          <div class="sidebar-header">
             <span class="sidebar-title"
               >Receive Special Offers and<br>
               First Look at New Products.</span
@@ -280,7 +276,7 @@
         </div>
 
         <div class="sidebar-section">
-          <div class="sidebar-header" onclick="toggleSection(this)">
+          <div class="sidebar-header">
             <span class="sidebar-title">Estimate Shipping Rates</span>
             <span class="expand-icon"><span class="pmorph__icon"></span></span>
           </div>
@@ -307,10 +303,8 @@
           </span>
         </div>
         {%- if cart == empty -%}
-          {%- assign checkout_disabled = 'disabled' -%}
           {%- assign checkout_wrapper_class = 'checkout-btn-wrapper cart-empty' -%}
         {%- else -%}
-          {%- assign checkout_disabled = '' -%}
           {%- assign checkout_wrapper_class = 'checkout-btn-wrapper' -%}
         {%- endif -%}
 

--- a/snippets/card-product.liquid
+++ b/snippets/card-product.liquid
@@ -79,7 +79,7 @@
   <div class="card-wrapper product-card-wrapper group">
     <div class="block card-inner-wrapper w-full">
       <div
-        class="relative w-full product-card-height transition-all duration-300 overflow-hidden"
+        class="relative w-full product-card-height overflow-hidden"
         style="background-color: var(--background);"
       >
         {%- if card_product.featured_media -%}
@@ -160,8 +160,6 @@
                 type="button"
                 class="notify-when-available-btn w-full py-4  font-medium cursor-pointer transition-colors duration-200 uppercase tracking-wider"
                 style="color:var(--button_label); background-color: var(--button);"
-                onmouseout="this.style.backgroundColor='var(--button)'; this.style.color='var(--button_label)';"
-                onmouseover="this.style.backgroundColor='var(--hovered_button_label)'; this.style.color='var(--hovered_button_text_color)';"
                 data-product-id="{{ card_product.id }}"
                 data-product-title="{{ card_product.title | escape }}"
               >
@@ -191,9 +189,6 @@
                 type="button"
                 class="add-to-cart-btn new-add-to-cart-btn {% if has_size_variant %}no-hover-css-product-card{% endif %} w-full py-4 z-[100] !text-[1.6rem] font-medium transition-colors duration-200 uppercase tracking-wider quick-add-button"
                 style="color:var(--button_label); background-color: var(--button);"
-
-                onmouseout="this.style.backgroundColor='var(--button)'; this.style.color='var(--button_label)';"
-                onmouseover="this.style.backgroundColor='var(--hovered_button_label)'; this.style.color='var(--hovered_button_text_color)';"
                 {% if has_size_variant %}
                   data-has-sizes="true"
                 {% else %}
@@ -358,7 +353,7 @@
   }
   /* On hover, decrease height (shrink from bottom only) */
   .card-wrapper:hover .product-card-height {
-    height: 470px;
+    height: 450px;
   }
   @media screen and (min-width: 1500px) {
     .product-card-height {
@@ -664,6 +659,18 @@
   .notify-when-available-btn {
     border-radius: 5px;
     font-size: 20px;
+  }
+
+  /* Hover styles for notify button (replaces inline handlers) */
+  .notify-when-available-btn:hover {
+    background-color: var(--hovered_button_label) !important;
+    color: var(--hovered_button_text_color) !important;
+  }
+
+  /* Hover styles for add to cart button (replaces inline handlers) */
+  .add-to-cart-btn:not(.no-hover-css-product-card):hover {
+    background-color: var(--hovered_button_label) !important;
+    color: var(--hovered_button_text_color) !important;
   }
 
   .add-to-cart-text,

--- a/snippets/cart-drawer.liquid
+++ b/snippets/cart-drawer.liquid
@@ -136,7 +136,6 @@
               <button
                 class="drawer__close2"
                 type="button"
-                onclick="this.closest('cart-drawer').close()"
                 aria-label="{{ 'accessibility.close' | t }}"
               >
                 <span
@@ -161,7 +160,6 @@
         <button
           class="drawer__close  !text-[16px]"
           type="button"
-          onclick="this.closest('cart-drawer').close()"
           aria-label="{{ 'accessibility.close' | t }}"
         >
           <span
@@ -818,10 +816,8 @@
 
         <div class="cart__ctas !ml-auto mt-5" {{ block.shopify_attributes }}>
           {%- if cart == empty -%}
-            {%- assign checkout_disabled = 'disabled' -%}
             {%- assign wrapper_class = 'checkout-button-wrapper cart-empty' -%}
           {%- else -%}
-            {%- assign checkout_disabled = '' -%}
             {%- assign wrapper_class = 'checkout-button-wrapper' -%}
           {%- endif -%}
 

--- a/snippets/facets.liquid
+++ b/snippets/facets.liquid
@@ -147,7 +147,6 @@
                     <summary
                       class="facets__summary caption-large focus-offset !p-0"
                       aria-label="{{ filter.label | escape }} ({{ 'products.facets.filters_selected.one' | t: count: filter.active_values.size | default: 'selected' }})"
-                      onclick="toggleArrow(this)"
                     >
                       <div class="flex items-center">
                         <h1
@@ -204,7 +203,7 @@
 
                             {%- capture text_value -%}
                               <span class="" aria-hidden="true">
-                                <span class="text-[16px] text-nowrap facets-text-color" onmouseout="this.style.backgroundColor='transparent'">{{- value.label | escape }}</span>
+                                <span class="text-[16px] text-nowrap facets-text-color">{{- value.label | escape }}</span>
                               </span>
                               <span class="visually-hidden">
                                 {{- value.label | escape }}
@@ -300,7 +299,7 @@
                   >
                     <summary
                       class="facets__summary caption-large focus-offset"
-                      onclick="this.closest('details').querySelector('.pmorph__icon').classList.toggle('expanded')"
+                      data-facet-summary="price"
                     >
                       <div class="flex items-center">
                         <h1
@@ -339,7 +338,7 @@
               >
                 <summary
                   class="facets__summary caption-large focus-offset -translate-y-[10px] !p-0"
-                  onclick="this.closest('details').querySelector('.pmorph__icon').classList.toggle('expanded')"
+                  data-facet-summary="sort"
                 >
                   <div class="flex items-center">
                     <h1 class="uppercase !text-[16px] w-[75px] !font-[500] facets-text-color">Sort By</h1>
@@ -366,8 +365,7 @@
                               {% if option.value == sort_by %}
                                 checked
                               {% endif %}
-                              onchange="handleSortByChange(this)"
-                              class="facets-hidden-input"
+                              class="facets-hidden-input sort-by-checkbox"
                             >
                             {{- 'square.svg' | inline_asset_content -}}
                             <div class="svg-wrapper translate-y-[5px] facets-svg-transform">
@@ -376,7 +374,6 @@
                             <span class="" aria-hidden="true">
                               <span
                                 class="text-[16px] text-nowrap facets-text-color"
-                                onmouseout="this.style.backgroundColor='transparent'"
                               >
                                 {{- option.name | escape -}}
                               </span>
@@ -407,9 +404,7 @@
       <div class="mobile-filter-header">
         <h2 class="!text-[30px] uppercase facets-mobile-header">FILTERS</h2>
         <div class="mobile-filter-apply">
-          <button type="button" class="mobile-filter-close facets-mobile-close" onclick="closeMobileFilters()">
-            Close
-          </button>
+          <button type="button" class="mobile-filter-close facets-mobile-close">Close</button>
         </div>
       </div>
 
@@ -505,7 +500,7 @@
           </div>
 
           <div class="mobile-filter-footer">
-            <button type="button" class="mobile-apply-btn" onclick="closeMobileFilters()">CLOSE</button>
+            <button type="button" class="mobile-apply-btn">CLOSE</button>
           </div>
         </form>
       </facet-filters-form>
@@ -553,7 +548,6 @@
 >
   <button
     class="mobile-facets-trigger flex items-center gap-2 px-4 py-2 w-1/2 justify-center facets-mobile-trigger"
-    onclick="openMobileFilters()"
   >
     <span class="uppercase filters-tabs facets-filters-tabs">Filters</span>
   </button>
@@ -561,7 +555,6 @@
   <div class="mobile-sort-dropdown relative w-1/2">
     <button
       class="mobile-sort-trigger flex items-center gap-2 px-4 py-2 w-full justify-center"
-      onclick="this.nextElementSibling.classList.toggle('hidden')"
     >
       <span class="uppercase filters-tabs facets-filters-tabs">Sort</span>
     </button>
@@ -584,8 +577,7 @@
                   {% if option.value == sort_by %}
                     checked
                   {% endif %}
-                  onchange="handleSortByChange(this)"
-                  class="facets-hidden-input"
+                  class="facets-hidden-input sort-by-checkbox"
                 >
                 {{- 'square.svg' | inline_asset_content -}}
                 <div class="svg-wrapper translate-y-[5px] facets-svg-transform">
@@ -594,7 +586,6 @@
                 <span class="" aria-hidden="true">
                   <span
                     class="text-[14px] text-nowrap facets-text-color"
-                    onmouseout="this.style.backgroundColor='transparent'"
                   >
                     {{- option.name | escape -}}
                   </span>
@@ -648,6 +639,55 @@
 
   // Add event listeners to all filter summaries
   document.addEventListener('DOMContentLoaded', function () {
+    // ===================================================================
+    // FACETS EVENT LISTENERS (CSP-compliant, replaces inline handlers)
+    // ===================================================================
+
+    // Toggle arrow for facet summaries (replaces onclick="toggleArrow(this)")
+    document.querySelectorAll('.facets__summary').forEach(function (summary) {
+      summary.addEventListener('click', function () {
+        toggleArrow(this);
+      });
+    });
+
+    // Handle price and sort summary icon toggles (replaces inline onclick)
+    document.querySelectorAll('[data-facet-summary]').forEach(function (summary) {
+      summary.addEventListener('click', function () {
+        this.closest('details').querySelector('.pmorph__icon').classList.toggle('expanded');
+      });
+    });
+
+    // Handle sort by checkbox changes (replaces onchange="handleSortByChange(this)")
+    document.querySelectorAll('.sort-by-checkbox').forEach(function (checkbox) {
+      checkbox.addEventListener('change', function () {
+        handleSortByChange(this);
+      });
+    });
+
+    // Mobile filter buttons
+    const mobileFilterTrigger = document.querySelector('.mobile-facets-trigger');
+    if (mobileFilterTrigger) {
+      mobileFilterTrigger.addEventListener('click', function () {
+        openMobileFilters();
+      });
+    }
+
+    // Mobile filter close buttons
+    document.querySelectorAll('.mobile-filter-close, .mobile-apply-btn').forEach(function (btn) {
+      btn.addEventListener('click', function () {
+        closeMobileFilters();
+      });
+    });
+
+    // Mobile sort trigger (replaces onclick to toggle dropdown)
+    document.querySelectorAll('.mobile-sort-trigger').forEach(function (trigger) {
+      trigger.addEventListener('click', function () {
+        this.nextElementSibling.classList.toggle('hidden');
+      });
+    });
+
+    console.log('✅ Facets event listeners initialized (CSP-compliant)');
+
     // Close dropdowns when clicking outside
     document.addEventListener('click', function (e) {
       if (

--- a/snippets/price-facet.liquid
+++ b/snippets/price-facet.liquid
@@ -12,7 +12,7 @@
 <div class="price-facet-container {% if filter_type == 'mobile' %}mobile-price-facet{% endif %}">
   <!-- CLEAR button in top right -->
   <div class="price-facet-header">
-    <span class="price-reset" onclick="resetPriceFilters(event)">{{ reset_label }}</span>
+    <span class="price-reset" role="button" tabindex="0" aria-label="Reset price filters">{{ reset_label }}</span>
   </div>
 
   <!-- Price Range Slider -->
@@ -27,7 +27,7 @@
           min="{{ range_min }}"
           max="{{ range_max }}"
           value="{{ min_price }}"
-          oninput="updatePriceSlider('{{ id_prefix }}', this)"
+          data-prefix="{{ id_prefix }}"
         >
         <input
           type="range"
@@ -36,7 +36,7 @@
           min="{{ range_min }}"
           max="{{ range_max }}"
           value="{{ max_price }}"
-          oninput="updatePriceSlider('{{ id_prefix }}', this)"
+          data-prefix="{{ id_prefix }}"
         >
       </div>
     </div>
@@ -57,8 +57,8 @@
           step="1"
           inputmode="numeric"
           placeholder="{{ currency_symbol }} {{ from_label }}"
-          onkeydown="handlePriceKeydown(event)"
-          oninput="updatePriceFromInput('{{ id_prefix }}', this.value, 'min')"
+          data-prefix="{{ id_prefix }}"
+          data-type="min"
         >
       </div>
 
@@ -76,8 +76,8 @@
           step="1"
           inputmode="numeric"
           placeholder="{{ currency_symbol }} {{ to_label }}"
-          onkeydown="handlePriceKeydown(event)"
-          oninput="updatePriceFromInput('{{ id_prefix }}', this.value, 'max')"
+          data-prefix="{{ id_prefix }}"
+          data-type="max"
         >
       </div>
     </div>
@@ -589,5 +589,50 @@
     document.querySelectorAll('.price-facet-container').forEach((container) => {
       updateSliderRange(container);
     });
+
+    // ===================================================================
+    // PRICE FACET EVENT LISTENERS (CSP-compliant, replaces inline handlers)
+    // ===================================================================
+
+    // Reset button click handlers
+    document.querySelectorAll('.price-reset').forEach(function (resetBtn) {
+      resetBtn.addEventListener('click', function (event) {
+        resetPriceFilters(event);
+      });
+
+      // Keyboard accessibility
+      resetBtn.addEventListener('keydown', function (event) {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          resetPriceFilters(event);
+        }
+      });
+    });
+
+    // Price slider input handlers
+    document.querySelectorAll('.price-slider-handle').forEach(function (slider) {
+      slider.addEventListener('input', function () {
+        const prefix = this.dataset.prefix;
+        updatePriceSlider(prefix, this);
+      });
+    });
+
+    // Price input field handlers
+    document.querySelectorAll('.price-input').forEach(function (input) {
+      // Keydown handler for Enter key
+      input.addEventListener('keydown', function (event) {
+        handlePriceKeydown(event);
+      });
+
+      // Input handler for real-time updates
+      input.addEventListener('input', function () {
+        const prefix = this.dataset.prefix;
+        const type = this.dataset.type;
+        const value = this.value;
+        updatePriceFromInput(prefix, value, type);
+      });
+    });
+
+    console.log('✅ Price facet event listeners initialized (CSP-compliant)');
   });
 </script>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replaces inline DOM handlers with CSP-compliant event listeners across cart drawer, email signup/password modal, cart page UI, and facets/price filters, while adding keyboard/ARIA accessibility and minor UI/CSS tweaks.
> 
> - **CSP & Accessibility**:
>   - Replace inline `onclick/oninput/onchange` with JS event listeners across `assets/*.js`, `snippets/*`, and `sections/*` for CSP compliance.
>   - Add keyboard handling (Enter/Space) and ARIA updates for buttons/headers (close buttons, password modal, facet summaries, mobile controls).
> - **Cart Drawer** (`assets/cart-drawer-custom.js`, `snippets/cart-drawer.liquid`):
>   - Add close button listeners; keep size/color change delegation; init logs.
>   - Remove inline close handlers in markup.
> - **Email Signup/Password Modal** (`assets/email-signup.js`, `sections/email-signup-banner.liquid`):
>   - Implement open/close modal functions with click/keyboard listeners; focus management; ARIA `aria-expanded` updates.
>   - Remove inline `onclick` in banner.
> - **Cart Page UI** (`assets/main-cart-items.js`, `sections/main-cart-items.liquid`):
>   - Add listeners for color pickers and sidebar headers (click/keyboard) replacing inline handlers; set roles/tabindex/`aria-expanded`.
>   - Keep quantity/note/shipping logic; init logs.
> - **Facets & Price Filters** (`snippets/facets.liquid`, `snippets/price-facet.liquid`):
>   - Replace inline handlers for facet summaries, sort checkboxes, mobile filters/sort, price reset/slider/inputs with JS listeners; wire to existing AJAX (`applyFiltersAjax`).
>   - Add `data-*` attributes to controls and keyboard support; minor cleanup of inline style events.
> - **Product Card CSS** (`snippets/card-product.liquid`):
>   - Move hover effects from inline to CSS; adjust hover height (470px→450px) and remove extra transition class.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 14560b884cc7ceec5381b8bc24763ca2c503df56. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->