### PR TITLE
removed hard coded values

### DIFF
--- a/assets/main-cart-items.css
+++ b/assets/main-cart-items.css
@@ -118,7 +118,6 @@
     max-width: 100%;
     margin: 0 auto;
     padding: var(--space-sm);
-    font-family: Arial, sans-serif;
     height: auto;
     display: flex;
     flex-direction: column;

--- a/snippets/price-facet.liquid
+++ b/snippets/price-facet.liquid
@@ -91,7 +91,6 @@
     padding: 16px;
     width: 280px;
     position: relative;
-    font-family: sans-serif;
   }
 
   .price-facet-header {
@@ -101,7 +100,6 @@
   }
 
   .price-reset {
-    font-family: sans-serif;
     font-size: 12px;
     color: #000;
     text-decoration: underline;
@@ -232,7 +230,6 @@
     padding: 8px 10px;
     border: 1px solid #000;
     border-radius: 4px;
-    font-family: sans-serif;
     font-size: 12px;
     background-color: white;
     color: #000;
@@ -260,7 +257,6 @@
   }
 
   .price-separator {
-    font-family: sans-serif;
     font-size: 14px;
     color: #000;
     font-weight: normal;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes hard-coded font-family declarations from cart page and price facet styles to inherit theme typography.
> 
> - **Styling**:
>   - **Cart (`assets/main-cart-items.css`)**: Remove `font-family` from `.cart-container`.
>   - **Price Facet (`snippets/price-facet.liquid`)**: Remove `font-family` from `.price-facet-container`, `.price-reset`, `.price-input`, and `.price-separator` to rely on inherited fonts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc8edff063a55d7eb9eff1321e94db89decf9561. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->