### PR TITLE
popup fixes

### DIFF
--- a/assets/popup.css
+++ b/assets/popup.css
@@ -215,9 +215,9 @@ input:focus {
     object-position: center center;
   }
 
-  /* Text section - bottom half in portrait, strictly equal padding all around */
+  /* Text section - bottom half in portrait, equal padding all around matching desktop */
   #popup-inner>div:first-child {
-    padding: var(--space-2xl) !important;
+    padding: var(--space-3xl) !important;
     display: flex !important;
     flex-direction: column !important;
     align-items: center !important;
@@ -306,6 +306,7 @@ input:focus {
     hyphens: auto;
     white-space: normal;
     overflow: visible;
+    padding-bottom: 0 !important;
   }
 
   /* Form container - centered */
@@ -317,6 +318,7 @@ input:focus {
     display: flex !important;
     flex-direction: column !important;
     align-items: center !important;
+    padding-top: var(--space-3xl) !important;
   }
 
   .promo-close {
@@ -345,11 +347,11 @@ input:focus {
     width: 50% !important;
   }
 
-  /* Text section - left side, full height, equal all-around padding */
+  /* Text section - left side, full height, equal padding matching desktop */
   #popup-inner>div:first-child {
     width: 50% !important;
     height: 100% !important;
-    padding: var(--space-xl) !important;
+    padding: var(--space-3xl) !important;
     justify-content: center !important;
   }
 
@@ -398,6 +400,12 @@ input:focus {
     margin-left: 0 !important;
     margin-right: 0 !important;
     font-size: clamp(var(--t-b-4-size), 1.5vw, var(--t-b-2-size)) !important;
+    padding-bottom: 0 !important;
+  }
+
+  /* Form container - proper spacing */
+  .email-signup-container {
+    padding-top: var(--space-3xl) !important;
   }
 }
 

--- a/sections/popup.liquid
+++ b/sections/popup.liquid
@@ -59,7 +59,7 @@
 
               <p
                 class="popup-bracket-header text-bracket-header-color text-sm tracking-tighter py-2 text-center"
-                style="font-family: var(--font-body-family);font-style:italic; font-size:var(--t-b-4-size); font-weight:var(--t-b-4-weight); line-height:var(--t-b-4-line-height); padding-bottom:var(--space-3xl);"
+                style="font-family: var(--font-body-family);font-style:italic; font-size:var(--t-b-4-size); font-weight:var(--t-b-4-weight); line-height:var(--t-b-4-line-height);"
               >
                 {% if section.settings.bracket_header != blank %}
                   ({{ section.settings.bracket_header }})


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refactors popup CSS for responsive desktop/tablet/mobile layouts and spacing, and removes hardcoded inline dimensions from the Liquid template.
> 
> - **Styles (`assets/popup.css`)**:
>   - **Responsive layout**:
>     - Add desktop (≥1296px) side-by-side layout with fixed vw/vh bounds.
>     - Redefine tablet (768–1295px) to stacked portrait by default; add landscape override to side-by-side.
>     - Revise mobile (<768px) to consistent 50/50 split and fixed 90vh container height.
>   - **Sizing/spacing tweaks**:
>     - Add horizontal padding to `.submit-btn` and email input; center and full-width adjustments across breakpoints.
>     - Update text sizing via clamp on tablet/landscape; center-align headers/subheaders; refine selectors and placeholder styles.
> - **Template (`sections/popup.liquid`)**:
>   - Remove inline width/height styles for `.divisionpopup` and `#popup-content` to defer to CSS.
>   - Clean up padding/margins and center the form; adjust email input padding to left/right variables.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b4299a723c2640f1712ce2f3dc269d7dad7bbb0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->