### PR TITLE
Fix primary button color variables

### DIFF
--- a/snippets/primary-button.liquid
+++ b/snippets/primary-button.liquid
@@ -59,9 +59,9 @@
     position: relative;
     display: inline-block;
     padding: 0px;
-    border: {{ settings.buttons_border_thickness | default: 1 }}px solid var(--secondary_button_text_color);
-    color: var(--secondary_button_text_color);
-    background-color: var(--secondary_button_label);
+    border: {{ settings.buttons_border_thickness | default: 1 }}px solid var(--button_label);
+    color: var(--button_label);
+    background-color: var(--button);
     border-radius: {{ settings.buttons_radius | default: 0 }}px;
     overflow: hidden;
     transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
@@ -73,9 +73,9 @@
 
   .primary-slide-button:hover,
   .primary-slide-button:focus {
-    background-color: var(--hovered_secondary_button_label);
-    color: var(--hovered_secondary_button_text_color);
-    border-color: var(--hovered_secondary_button_text_color);
+    background-color: var(--hovered_button_label);
+    color: var(--hovered_button_text_color);
+    border-color: var(--hovered_button_text_color);
     outline: none;
     text-decoration: none;
   }
@@ -192,7 +192,13 @@
       >
         {{ button_text | escape }}
         <span class="primary-slide-button-arrow" aria-hidden="true">
-          {% render 'icon-playback', width: '16', height: '16', viewBox: '4.5 1.5 8.5 13', stoke: 'currentColor', fill: 'currentColor' %}
+          {% render 'icon-playback',
+            width: '16',
+            height: '16',
+            viewBox: '4.5 1.5 8.5 13',
+            stoke: 'currentColor',
+            fill: 'currentColor'
+          %}
         </span>
       </div>
     </div>
@@ -211,7 +217,13 @@
       >
         {{ button_text | escape }}
         <span class="primary-slide-button-arrow" aria-hidden="true">
-          {% render 'icon-playback', width: '16', height: '16px', viewBox: '4.5 1.5 8.5 13', stoke: 'currentColor', fill: 'currentColor' %}
+          {% render 'icon-playback',
+            width: '16',
+            height: '16px',
+            viewBox: '4.5 1.5 8.5 13',
+            stoke: 'currentColor',
+            fill: 'currentColor'
+          %}
         </span>
       </div>
       <div
@@ -220,7 +232,13 @@
       >
         {{ button_text | escape }}
         <span class="primary-slide-button-arrow" aria-hidden="true">
-          {% render 'icon-playback', width: '16', height: '16', viewBox: '4.5 1.5 8.5 13', stoke: 'currentColor', fill: 'currentColor' %}
+          {% render 'icon-playback',
+            width: '16',
+            height: '16',
+            viewBox: '4.5 1.5 8.5 13',
+            stoke: 'currentColor',
+            fill: 'currentColor'
+          %}
         </span>
       </div>
     </div>


### PR DESCRIPTION
- Changed primary-button.liquid to use correct primary button variables
- Background now uses var(--button) instead of var(--secondary_button_label)
- Text color now uses var(--button_label) instead of var(--secondary_button_text_color)
- Hover states now use var(--hovered_button_label) and var(--hovered_button_text_color)
- Fixes issue where primary buttons showed black background instead of white

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches `snippets/primary-button.liquid` to primary button CSS variables for base and hover styles.
> 
> - **UI/Theming**:
>   - Update `snippets/primary-button.liquid` to use primary button variables for border, text, and background (`--button_label`, `--button`) and hover states (`--hovered_button_label`, `--hovered_button_text_color`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e201ad5c0cd73856c3d897503c8c5216521b2402. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->