### PR TITLE
popup close button

### DIFF
--- a/assets/popup.css
+++ b/assets/popup.css
@@ -480,15 +480,15 @@ input:focus {
   }
 
   #popup-content {
-    width: 93vw !important;
-    height: 90vh !important;
-    max-height: 90vh !important;
+    width: 90vw !important;
+    height: 80vh !important;
+    max-height: 80vh !important;
   }
 
   .divisionpopup {
-    height: 90vh !important;
-    max-height: 90vh !important;
-    width: 93vw !important;
+    height: 80vh !important;
+    max-height: 80vh !important;
+    width: 90vw !important;
     display: flex;
     flex-direction: column;
     /* Stack vertically for mobile */
@@ -534,20 +534,69 @@ input:focus {
   }
 
   .promo-close {
-    width: 16vw !important;
-    height: 12vh !important;
+    width: 42px !important;
+    height: 42px !important;
+    background-color: var(--popup-close-button-bg, #ffffff) !important;
+    border-radius: 50% !important;
+    display: flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+    border: none !important;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15) !important;
+    transition: all 0.2s ease !important;
+    color: var(--text) !important;
+    z-index: 9999 !important;
+  }
+  
+  .promo-close:hover {
+    background-color: #f5f5f5 !important;
+    color: var(--text) !important;
+    transform: scale(1.05) !important;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2) !important;
+  }
+  
+  .promo-close:active {
+    transform: scale(0.95) !important;
   }
 
-  /* Mobile styles for get-access button to match tertiary button */
-  #get-access .button-text,
-  #get-access .button-text-hover {
-    font-size: var(--tm-b-2-size) !important;
-    font-weight: var(--tm-b-2-weight) !important;
-    line-height: var(--tm-b-2-line-height) !important;
-  }
+
+/* Mobile styles for get-access button to match tertiary button */
+#get-access .button-text,
+#get-access .button-text-hover {
+  font-size: var(--tm-b-2-size) !important;
+  font-weight: var(--tm-b-2-weight) !important;
+  line-height: var(--tm-b-2-line-height) !important;
+}
 
   .submit-btn .rotate-arrow {
     width: var(--t-b-3-size);
     height: var(--t-b-3-size);
   }
+}
+
+/* Close button styling - ALL views (desktop, tablet, mobile) - OUTSIDE media queries */
+.promo-close {
+  width: 42px !important;
+  height: 42px !important;
+  background-color: var(--popup-close-button-bg, #ffffff) !important;
+  border-radius: 50% !important;
+  display: flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  border: none !important;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15) !important;
+  transition: all 0.2s ease !important;
+  color: var(--text) !important;
+  z-index: 9999 !important;
+}
+
+.promo-close:hover {
+  background-color: #f5f5f5 !important;
+  color: var(--text) !important;
+  transform: scale(1.05) !important;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2) !important;
+}
+
+.promo-close:active {
+  transform: scale(0.95) !important;
 }

--- a/sections/popup.liquid
+++ b/sections/popup.liquid
@@ -1,5 +1,11 @@
 <link rel="stylesheet" href="{{ 'popup.css' | asset_url }}">
 
+<style>
+  :root {
+    --popup-close-button-bg: {{ section.settings.close_button_bg_color | default: '#ffffff' }};
+  }
+</style>
+
 <div
   id="promo-overlay"
   class="fixed inset-0 bg-black/50 hidden z-[1000] overflow-y-auto"
@@ -17,7 +23,7 @@
       >
         <svg role="img" width="35" height="35" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
           <title id="title-Close-dialog">Close dialog</title>
-          <path d="M6 6L14 14M6 14L14 6L6 14Z" stroke="var(--text)" stroke-width="1" stroke-linecap="round" stroke-linejoin="round" style="cursor: pointer;"></path>
+          <path d="M6 6L14 14M6 14L14 6L6 14Z" stroke="currentColor" stroke-width="1" stroke-linecap="round" stroke-linejoin="round"/>
         </svg>
       </button>
 
@@ -393,6 +399,12 @@
       "id": "declaration",
       "default": "By clicking submit, you agree to our terms and conditions.",
       "label": "Declaration text below offer accept"
+    },
+    {
+      "type": "color",
+      "id": "close_button_bg_color",
+      "default": "#ffffff",
+      "label": "Close button background color"
     }
   ],
   "presets": [{ "name": "Pop Up" }]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Styles the popup close button as a 42px circular control with hover/active states and configurable background color, switches icon to currentColor, and reduces mobile popup dimensions to 90vw/80vh.
> 
> - **UI/CSS**:
>   - **Close button**: Add unified `.promo-close` styling across views (42px circular button, shadow, hover/active effects; uses `currentColor`).
>   - **Mobile sizing**: Reduce `#popup-content` and `.divisionpopup` to `90vw`/`80vh`.
>   - **Button text styles**: Move `#get-access` typography rules outside mobile media query for consistency.
> - **Liquid/Theme settings**:
>   - Define `--popup-close-button-bg` from `section.settings.close_button_bg_color` and apply in CSS.
>   - SVG close icon stroke switched to `currentColor`.
>   - Schema: add `close_button_bg_color` setting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ae98bf1954b2cfd4fced912a59b8962fb864c0c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->