### PR TITLE
sold out badge rendered in outfit inspiration

### DIFF
--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -274,7 +274,7 @@
         --z-tooltip: 3000;            /* Tooltips */
         --z-debug: 9999;              /* Debug tools, skip links */
         --z-sort-search: 999999
-        
+
         --grid-desktop-vertical-spacing: {{ settings.spacing_grid_vertical }}px;
         --grid-desktop-horizontal-spacing: {{ settings.spacing_grid_horizontal }}px;
         --grid-mobile-vertical-spacing: {{ settings.spacing_grid_vertical | divided_by: 2 }}px;

--- a/sections/outfit_inspiration.liquid
+++ b/sections/outfit_inspiration.liquid
@@ -487,8 +487,11 @@
     .outfit-paired-title .new-product-price .price-item {
       font-size: 14px !important;
     }
-    .outfit-wrapper{
-      gap: 20px;
+    /* Desktop gap for outfit wrapper */
+    @media (min-width: 768px) {
+      .outfit-wrapper {
+        gap: 20px;
+      }
     }
 
     /* Hide price in mobile view for paired products */
@@ -513,7 +516,7 @@
       color: var(--header_text, var(--color-foreground));
       margin-bottom: 45px;
     }
-    /* Removed outfit-sold-out styles to use global sold-out-badge settings */
+
 
   .outfit-add-to-cart-btn-{{ section.id }} {
     display: flex !important;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replace inline SOLD OUT label with `sold-out-badge` snippet, standardize border radii via `--sold-out-badge-radius`, tweak spacing, and remove section `buttons_radius` setting.
> 
> - **Outfit Inspiration (`sections/outfit_inspiration.liquid`)**:
>   - **Sold-out Badge**: Replace inline SOLD OUT markup with `{% render 'sold-out-badge' %}` for paired products; remove local `.outfit-sold-out` styles.
>   - **Radii Standardization**: Use `--sold-out-badge-radius` for `.main-product-card`, `.paired-product-card`, `.expanded-product-card`, and size options; add `!important` where applied.
>   - **Layout Spacing**: Adjust `.outfit-size` padding-bottom (36px → 30px); set `.outfit-wrapper` gap to 12px with desktop override to 20px.
>   - **Schema**: Remove `buttons_radius` range setting from section schema.
> - **Theme (`layout/theme.liquid`)**:
>   - Minor whitespace change near `--z-sort-search`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 87b317a4183106f1666d5bdefeef3924975bfc23. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->