### PR TITLE
Add toggle control for footer background animation

### DIFF
--- a/assets/footer.css
+++ b/assets/footer.css
@@ -39,6 +39,11 @@
       animation: backgroundMove 10s linear infinite;
       z-index: var(--z-background-deep);
     }
+    .animated-footer-background.paused {
+      animation: none;
+      background-size: cover;
+      background-position: center;
+    }
     @keyframes backgroundMove {
       0% { background-position: 0% 0%; background-size: 120% 120%; }
       25% { background-position: 100% 0%; background-size: 125% 125%; }

--- a/sections/footer.liquid
+++ b/sections/footer.liquid
@@ -500,6 +500,13 @@
       "info": "Select an image from your files for the animated background effect. Leave empty to use the default pattern."
     },
     {
+      "type": "checkbox",
+      "id": "enable_bg_animation",
+      "label": "Enable Background Animation",
+      "default": true,
+      "info": "Animate the background image with a subtle movement and zoom effect"
+    },
+    {
       "type": "header",
       "content": "Spacing"
     },


### PR DESCRIPTION
- Added 'enable_bg_animation' checkbox setting to footer schema
- Added CSS rule to pause animation when setting is disabled
- Default is enabled to maintain current behavior
- Fixes missing setting that was referenced but not defined

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `enable_bg_animation` footer setting and corresponding CSS to pause the animated background when disabled.
> 
> - **Footer UI**:
>   - **Liquid**: Conditionally applies `paused` to `animated-footer-background` when `section.settings.enable_bg_animation == false`.
>   - **Schema**: Adds `checkbox` setting `enable_bg_animation` (default: `true`) to control background animation.
> - **Styles**:
>   - Adds `.animated-footer-background.paused` to stop animation and use `background-size: cover; background-position: center`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ebac932be239a3da44638bf90f217be9e2cf6ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->