### PR TITLE
Varun11

### DIFF
--- a/sections/product-difference.liquid
+++ b/sections/product-difference.liquid
@@ -256,10 +256,18 @@
           height="{{ image_after.width | divided_by: image_after.aspect_ratio | round }}"
           loading="eager"
           fetchpriority="high"
-          {% if section.settings.enable_right_tint %}style="opacity: 0.7;"{% endif %}
+          {% unless section.settings.enable_right_tint == false %}
+            style="opacity: 0.7;"
+          {% endunless %}
         >
       {% else %}
-        <div {% if section.settings.enable_right_tint %}style="opacity: 0.7;"{% endif %}>{{ 'lifestyle-2' | placeholder_svg_tag: 'prod-diff-img' }}</div>
+        <div
+          {% unless section.settings.enable_right_tint == false %}
+            style="opacity: 0.7;"
+          {% endunless %}
+        >
+          {{ 'lifestyle-2' | placeholder_svg_tag: 'prod-diff-img' }}
+        </div>
       {% endif %}
 
       <div id="BeforeImage-{{ section.id }}" class="prod-diff-img prod-diff-img--before">


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds `enable_right_tint` setting to toggle the opacity tint on the right/“after” image (and its placeholder) in `sections/product-difference.liquid`.
> 
> - **Product Difference Slider (`sections/product-difference.liquid`)**
>   - **UI Behavior**: Apply `style="opacity: 0.7;"` to right/after image and placeholder only when `section.settings.enable_right_tint` is enabled.
>   - **Theme Settings**: Add new checkbox setting `enable_right_tint` with default `true` and info text to control the right-side tint overlay.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eef89cc1cf65eec739317b8c47077b06ddd7dff8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->