### PR TITLE
Fix product-difference slider z-index conflicts

### DIFF
--- a/sections/product-difference.liquid
+++ b/sections/product-difference.liquid
@@ -122,8 +122,8 @@
 
     .prod-diff-slider-handle-chevron svg {
       transition: all 0.2s ease;
-      width: {{ section.settings.handle_width_desktop | default: 137 }}px;
-      height: {{ section.settings.handle_height_desktop | default: 51 }}px;
+      width: {{ section.settings.handle_width_desktop | default: 135 }}px;
+      height: {{ section.settings.handle_height_desktop | default: 50 }}px;
     }
 
     /* Responsive handle sizing for mobile */


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Reworks product-difference slider stacking order using design tokens and adds responsive, configurable handle dimensions with new theme settings.
> 
> - **UI/Styles (sections/product-difference.liquid)**:
>   - Normalize z-index layers:
>     - `.prod-diff-section` now uses `z-index: var(--z-base)`.
>     - `.prod-diff-slider-range` to `var(--z-content-elevated)`.
>     - `.prod-diff-slider-divider` and `.prod-diff-slider-handle-chevron` to `var(--z-content)`.
>     - Product info z-index: `.left` elevated, `.right` content.
>   - **Handle sizing**: Set SVG width/height from `section.settings`, with a mobile media query for responsive sizes.
> - **Theme settings**:
>   - Add `handle_width_desktop`, `handle_height_desktop`, `handle_width_mobile`, `handle_height_mobile` range controls for the slider handle.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 449e8518de85ead74374e1a298d6c352abfe6d35. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->