### PR TITLE
product difference slider fix

### DIFF
--- a/sections/product-difference.liquid
+++ b/sections/product-difference.liquid
@@ -196,8 +196,10 @@
   }
 
     /* --- COMMENT: Hide default labels with minimal CSS --- */
-    .prod-diff-default-label {
-      display: none;
+    .prod-diff-product-info.default-label {
+      display: none !important;
+      visibility: hidden !important;
+      opacity: 0 !important;
     }
 </style>
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Simplifies CSS to remove positioning/styling and hide default before/after labels in the product difference slider.
> 
> - **CSS (sections/product-difference.liquid)**:
>   - Remove detailed positioning and styling for `
> .prod-diff-default-labels` and `
> .prod-diff-default-label`.
>   - Add minimal rule to hide `
> .prod-diff-default-label` via `display: none;` to suppress default labels.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 07e4fe1c147af5eea901cbd7558d94278cd8a579. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->