### PR TITLE
two stage animation fixed

### DIFF
--- a/snippets/card-product.liquid
+++ b/snippets/card-product.liquid
@@ -428,23 +428,15 @@
   /* Responsive fixed height for image container */
   .product-card-height {
     height: 500px;
-    transition: height 0.3s ease;
     width: 100%;
     max-width: 100%;
     background: var(--background);
     position: relative;
     overflow: hidden;
   }
-  /* On hover, decrease height (shrink from bottom only) */
-  .card-wrapper:hover .product-card-height {
-    height: 450px;
-  }
   @media screen and (min-width: 1500px) {
     .product-card-height {
       height: 380px !important;
-    }
-    .card-wrapper:hover .product-card-height {
-      height: 350px !important;
     }
   }
   @media only screen and (max-width: 600px) {
@@ -459,10 +451,6 @@
     }
     .card-product-typegraphy {
       font-size: 12px !important;
-    }
-    /* Disable hover effect on mobile - keep original height */
-    .card-wrapper:hover .product-card-height {
-      height: 270px;
     }
     .product-card-text {
       font-size: 12px;
@@ -502,11 +490,6 @@
   .slider-arrow:hover {
     background: transparent !important;
     box-shadow: none !important;
-  }
-
-  /* Disable all hover animations on mobile devices */
-  .card-wrapper:hover .product-card-height {
-    height: 270px !important;
   }
 
   /* Ensure images stay visible */
@@ -555,11 +538,6 @@
 
   /* Additional mobile-only hover disabling using touch detection */
   @media (hover: none) and (pointer: coarse) {
-    /* Completely disable height changes on touch devices */
-    .card-wrapper:hover .product-card-height,
-    .group:hover .product-card-height {
-      height: 270px !important;
-    }
 
     /* CRITICAL: Keep ONLY first image visible, hide all others */
     .image-config {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes hover-driven height changes from product cards and cleans up mobile/touch hover rules to keep images visible without height animations.
> 
> - **Styles (snippets/card-product.liquid)**
>   - Remove hover height animation for `
> .product-card-height` (desktop and large screens) and associated transition.
>   - Delete mobile/touch hover height overrides in `@media (max-width: 600px)` and `@media (hover: none) and (pointer: coarse)`.
>   - Retain image visibility rules on hover (keep first image visible) and slider/button behaviors; remove redundant mobile hover animations for slider arrows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ef9c452d4349d04a9b7922d7fff7156068e7766. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->