### PR TITLE
variables changed for tabs

### DIFF
--- a/assets/main-product.css
+++ b/assets/main-product.css
@@ -155,7 +155,7 @@
 
 
 .tab-button-active {
-  color: var(--text);
+  color: var(--hovered_button_label);
   font-weight: var(--t-b-3-weight);
   font-size: var(--t-b-3-size);
   line-height: var(--t-b-3-line-height);
@@ -173,7 +173,7 @@
 }
 
 .tab-indicator-active {
-  background-color: var(--text);
+  background-color: var(--hovered_button_label);
 }
 
 .tab-indicator-inactive {

--- a/assets/main-product.js
+++ b/assets/main-product.js
@@ -1136,10 +1136,10 @@ document.addEventListener('DOMContentLoaded', () => {
         });
 
         button.classList.add('active-tab');
-        button.style.color = 'var(--text)';
+        button.style.color = 'var(--hovered_button_label)';
 
         if (borderDiv) {
-          borderDiv.style.backgroundColor = 'var(--text)';
+          borderDiv.style.backgroundColor = 'var(--hovered_button_label)';
         }
         tabPanes.forEach((pane) => {
           if (pane.getAttribute('data-content') === targetTab) {
@@ -1156,9 +1156,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
       button.addEventListener('mouseenter', () => {
         if (!button.classList.contains('active-tab')) {
-          button.style.color = 'var(--text)';
+          button.style.color = 'var(--hovered_button_label)';
           if (borderDiv) {
-            borderDiv.style.backgroundColor = 'var(--text)';
+            borderDiv.style.backgroundColor = 'var(--hovered_button_label)';
           }
         }
       });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switch tab active/hover text and indicator colors from `--text` to `--hovered_button_label` in CSS and JS.
> 
> - **UI/Styles**
>   - **Tabs**:
>     - Update active tab text color and indicator from `var(--text)` to `var(--hovered_button_label)` in `assets/main-product.css` (`.tab-button-active`, `.tab-indicator-active`).
>     - Mirror the same variable change in `assets/main-product.js` for runtime styles on click/hover (`.tab-btn`, `.mobile-tab-btn`), including `.tab-top-bar` background color.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c2807914f05f2d6a9d782d1b077eccc84c2b36e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->