### PR TITLE
progressive jpgs

### DIFF
--- a/snippets/card-collection.liquid
+++ b/snippets/card-collection.liquid
@@ -39,30 +39,50 @@
         style="background-color: var(--background);"
       >
         {%- if card_collection.featured_image -%}
-          <img
-            srcset="
-              {%- if card_collection.featured_image.width >= 360 -%}{{ card_collection.featured_image | image_url: width: 360 }} 360w,{%- endif -%}
-              {%- if card_collection.featured_image.width >= 533 -%}{{ card_collection.featured_image | image_url: width: 533 }} 533w,{%- endif -%}
-              {%- if card_collection.featured_image.width >= 720 -%}{{ card_collection.featured_image | image_url: width: 720 }} 720w,{%- endif -%}
-              {%- if card_collection.featured_image.width >= 940 -%}{{ card_collection.featured_image | image_url: width: 940 }} 940w,{%- endif -%}
-              {%- if card_collection.featured_image.width >= 1066 -%}{{ card_collection.featured_image | image_url: width: 1066 }} 1066w,{%- endif -%}
-              {%- if card_collection.featured_image.width >= 1200 -%}{{ card_collection.featured_image | image_url: width: 1200 }} 1200w,{%- endif -%}
-              {%- if card_collection.featured_image.width >= 1500 -%}{{ card_collection.featured_image | image_url: width: 1500 }} 1500w,{%- endif -%}
-              {%- if card_collection.featured_image.width >= 1800 -%}{{ card_collection.featured_image | image_url: width: 1800 }} 1800w,{%- endif -%}
-              {{ card_collection.featured_image | image_url }} {{ card_collection.featured_image.width }}w
-            "
-            src="{{ card_collection.featured_image | image_url: width: 1200 }}"
-            sizes="
-              (min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | divided_by: columns }}px,
-              (min-width: 750px) {% if columns > 1 %}calc((100vw - 10rem) / 2){% else %}calc(100vw - 10rem){% endif %},
-              calc(100vw - 3rem)
-            "
-            alt="{{ card_collection.featured_image.alt | escape }}"
-            height="{{ card_collection.featured_image.height }}"
-            width="{{ card_collection.featured_image.width }}"
-            loading="lazy"
-            style=" width: 100%; height: 100%; position: absolute; top: 0; left: 0;"
-          >
+          <picture>
+            <source
+              media="(min-width: 1px)"
+              srcset="
+                {%- if card_collection.featured_image.width >= 360 -%}{{ card_collection.featured_image | image_url: width: 360, format: 'pjpg' }} 360w,{%- endif -%}
+                {%- if card_collection.featured_image.width >= 533 -%}{{ card_collection.featured_image | image_url: width: 533, format: 'pjpg' }} 533w,{%- endif -%}
+                {%- if card_collection.featured_image.width >= 720 -%}{{ card_collection.featured_image | image_url: width: 720, format: 'pjpg' }} 720w,{%- endif -%}
+                {%- if card_collection.featured_image.width >= 940 -%}{{ card_collection.featured_image | image_url: width: 940, format: 'pjpg' }} 940w,{%- endif -%}
+                {%- if card_collection.featured_image.width >= 1066 -%}{{ card_collection.featured_image | image_url: width: 1066, format: 'pjpg' }} 1066w,{%- endif -%}
+                {%- if card_collection.featured_image.width >= 1200 -%}{{ card_collection.featured_image | image_url: width: 1200, format: 'pjpg' }} 1200w,{%- endif -%}
+                {%- if card_collection.featured_image.width >= 1500 -%}{{ card_collection.featured_image | image_url: width: 1500, format: 'pjpg' }} 1500w,{%- endif -%}
+                {%- if card_collection.featured_image.width >= 1800 -%}{{ card_collection.featured_image | image_url: width: 1800, format: 'pjpg' }} 1800w{%- endif -%}
+              "
+              sizes="
+                (min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | divided_by: columns }}px,
+                (min-width: 750px) {% if columns > 1 %}calc((100vw - 10rem) / 2){% else %}calc(100vw - 10rem){% endif %},
+                calc(100vw - 3rem)
+              "
+              type="image/jpeg"
+            >
+            <img
+              srcset="
+                {%- if card_collection.featured_image.width >= 360 -%}{{ card_collection.featured_image | image_url: width: 360 }} 360w,{%- endif -%}
+                {%- if card_collection.featured_image.width >= 533 -%}{{ card_collection.featured_image | image_url: width: 533 }} 533w,{%- endif -%}
+                {%- if card_collection.featured_image.width >= 720 -%}{{ card_collection.featured_image | image_url: width: 720 }} 720w,{%- endif -%}
+                {%- if card_collection.featured_image.width >= 940 -%}{{ card_collection.featured_image | image_url: width: 940 }} 940w,{%- endif -%}
+                {%- if card_collection.featured_image.width >= 1066 -%}{{ card_collection.featured_image | image_url: width: 1066 }} 1066w,{%- endif -%}
+                {%- if card_collection.featured_image.width >= 1200 -%}{{ card_collection.featured_image | image_url: width: 1200 }} 1200w,{%- endif -%}
+                {%- if card_collection.featured_image.width >= 1500 -%}{{ card_collection.featured_image | image_url: width: 1500 }} 1500w,{%- endif -%}
+                {%- if card_collection.featured_image.width >= 1800 -%}{{ card_collection.featured_image | image_url: width: 1800 }} 1800w{%- endif -%}
+              "
+              src="{{ card_collection.featured_image | image_url: width: 1200 }}"
+              sizes="
+                (min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | divided_by: columns }}px,
+                (min-width: 750px) {% if columns > 1 %}calc((100vw - 10rem) / 2){% else %}calc(100vw - 10rem){% endif %},
+                calc(100vw - 3rem)
+              "
+              alt="{{ card_collection.featured_image.alt | escape }}"
+              height="{{ card_collection.featured_image.height }}"
+              width="{{ card_collection.featured_image.width }}"
+              loading="lazy"
+              style=" width: 100%; height: 100%; position: absolute; top: 0; left: 0;"
+            >
+          </picture>
         {%- else -%}
           <div
             class="w-full h-full flex items-center justify-center"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Serve collection card images via a picture element with progressive JPEG sources and a fallback img, preserving responsive behavior.
> 
> - **Frontend (Liquid)**:
>   - **Image rendering in `snippets/card-collection.liquid`**:
>     - Replace single `img` with a `picture` element providing a `source` that serves progressive JPEGs (`format: 'pjpg'`) across responsive `srcset` widths.
>     - Retain fallback `img` with existing `srcset`, `sizes`, lazy-loading, and styling.
>     - No changes to placeholders or surrounding card layout/styles.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be4514b92cf3ab58a84705f1fa6c696b08035405. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->