### PR TITLE
social-media section updated

### DIFF
--- a/sections/main-article.liquid
+++ b/sections/main-article.liquid
@@ -169,14 +169,13 @@
 >
 <div
   class="social-section"
-  style="font-weight:500; height: 7.8vh; padding-left:{{ settings.side_space}}px; padding-right:{{ settings.side_space }}px;"
+  style="font-weight:500; padding-top: var(--space-xl); padding-bottom: var(--space-xl); padding-left:{{ settings.side_space}}px; padding-right:{{ settings.side_space }}px;"
 >
   <div
     class="social-media items-center "
-    style="color: var(--text); padding-top:13px; padding-bottom:20px; font-size:var(--tm-b-2-size);height: 7.8vh;"
+    style="color: var(--text); font-size:var(--tm-b-2-size); display: flex; align-items: center;"
   >
-    <span class="sharebtn text-xl md:text-2xl items-center;" style="margin-right:20px; margin-top:0.7vw">SHARE</span>
-
+    <span class="sharebtn text-xl md:text-2xl items-center;" style="margin-right:20px;">SHARE</span>
 
     <a
       href="#"
@@ -185,7 +184,7 @@
       aria-label="Share on Facebook"
       class="fb text-xl md:text-2xl"
       style="margin-right:40px;"
-      onclick="var url = getCanonicalUrl(); window.open('https://www.facebook.com/sharer.php?u=' + encodeURIComponent(url), 'facebook-share', 'width=580,height=400'); return false;"
+      onclick="var url = getCanonicalUrl(); window.open('https://www.facebook.com/sharer.php?u=' + encodeURIComponent(url), '_blank'); return false;"
     >
       FACEBOOK
     </a>
@@ -197,7 +196,7 @@
       aria-label="Share on Twitter"
       class="tw text-xl md:text-2xl"
       style="margin-right:40px;"
-      onclick="var url = getCanonicalUrl(); window.open('https://twitter.com/intent/tweet?url=' + encodeURIComponent(url) + '&text=' + encodeURIComponent(document.title || '{{ article.title | escape }}'), 'twitter-share', 'width=580,height=400'); return false;"
+      onclick="var url = getCanonicalUrl(); window.open('https://twitter.com/intent/tweet?url=' + encodeURIComponent(url) + '&text=' + encodeURIComponent(document.title || '{{ article.title | escape }}'), '_blank'); return false;"
     >
       TWITTER
     </a>
@@ -219,7 +218,7 @@
       aria-label="Share on LinkedIn"
       class="linked text-xl md:text-2xl"
       style="margin-right:40px;"
-      onclick="var url = getCanonicalUrl(); window.open('https://www.linkedin.com/sharing/share-offsite/?url=' + encodeURIComponent(url), 'linkedin-share', 'width=580,height=400'); return false;"
+      onclick="var url = getCanonicalUrl(); window.open('https://www.linkedin.com/sharing/share-offsite/?url=' + encodeURIComponent(url), '_blank'); return false;"
     >
       LINKEDIN
     </a>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refines the social share section layout and changes Facebook/Twitter/LinkedIn share actions to open in a new tab instead of pop-up windows.
> 
> - **Social share section (`sections/main-article.liquid`)**:
>   - **Layout/spacing**: Replace fixed height with vertical padding; align content with flex and center alignment; remove extra margins on the SHARE label.
>   - **Share behavior**: Update `onclick` for Facebook, Twitter, and LinkedIn to `window.open(..., '_blank')` (no sized pop-up windows).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ef28503e96741c90fec9e3129177d6d9faef98bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->