### PR TITLE
z index clash with header resolved

### DIFF
--- a/assets/main-cart-items.css
+++ b/assets/main-cart-items.css
@@ -125,7 +125,7 @@
     flex-direction: column;
 }
 
-.cart-header {
+.cart-head1 {
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -983,7 +983,7 @@ details:not([open]) .pmorph__icon::after {
         font-size: var(--tm-b-2-size);
         line-height: var(--tm-b-2-line-height);
     }
-    .cart-header {
+    .cart-head1 {
         margin-bottom: 0;
     }
 

--- a/sections/localization-selector.liquid
+++ b/sections/localization-selector.liquid
@@ -100,7 +100,10 @@
             <localization-form class="footer__language-selector">
               {%- form 'localization', id: 'FooterLanguageForm', class: 'localization-form' -%}
                 <div class="localization-selector">
-                  {%- render 'language-localization', localPosition: 'FooterLanguage', dropdown_icon: section.settings.dropdown_icon -%}
+                  {%- render 'language-localization',
+                    localPosition: 'FooterLanguage',
+                    dropdown_icon: section.settings.dropdown_icon
+                  -%}
                 </div>
               {%- endform -%}
             </localization-form>
@@ -379,10 +382,10 @@
     }
 
     .footer__localization,
-  .footer__country-selector,
-  .footer__language-selector {
-    z-index: 1000;
-  }
+    .footer__country-selector,
+    .footer__language-selector {
+      z-index: 1;
+    }
   }
 
   /* Tablet */

--- a/sections/main-cart-items.liquid
+++ b/sections/main-cart-items.liquid
@@ -1,7 +1,7 @@
 {{ 'main-cart-items.css' | asset_url | stylesheet_tag }}
 
 <div class="cart-container">
-  <div class="cart-header">
+  <div class="cart-head1">
     <h2 class="cart-title">Cart [{{ cart.item_count }}]</h2>
   </div>
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Lowers mobile z-index for footer localization dropdowns to avoid stacking issues and renames the cart header class from `cart-header` to `cart-head1` across CSS and template.
> 
> - **Footer/Localization**:
>   - Reduce mobile z-index for `footer__country-selector` and `footer__language-selector` to `1` to prevent stacking conflicts.
> - **Cart**:
>   - Rename header class from `cart-header` to `cart-head1` in `assets/main-cart-items.css` and `sections/main-cart-items.liquid` (including media query references).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 88cc1a9ba2672e555c600a9b8604711a9ccbb12f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->