### PR TITLE
load more button ui + functionality fixes

### DIFF
--- a/assets/blog-grid.css
+++ b/assets/blog-grid.css
@@ -25,6 +25,7 @@
   @media (max-width: 767px) {
     .load-more-btn-fb-container {
       margin-top:0px !important;
+      cursor: pointer;
     }
     .arrow-svgsub{
       height:17px;
@@ -42,6 +43,12 @@ height:18px !important;
 }
 .load-more-text-container, .load-more-text,.load-more-text-hover{
   height:18px !important;
+}
+
+/* Blog posts load more button mobile */
+.blog-section-container .blog-posts-load-more-btn {
+  min-width: 104px;
+  width: auto !important;
 }
     .blog_highlight-tag{
       font-size:var(--tm-h-3-size) !important;
@@ -170,13 +177,15 @@ height:18px !important;
   }
 
   @media (min-width: 1024px) {
-.load-more-btn-fb-container {
+/* Scope load more button styles to blog-grid section only */
+.blog-section-container .load-more-btn-fb-container {
   margin-top: 40px;
   display: flex;
   justify-content: end;
+  cursor: pointer;
 }
 
-.load-more-btn-fb {
+.blog-section-container .load-more-btn-fb {
   font-family: var(--font-body-family);
   position: relative;
   overflow: hidden;
@@ -188,15 +197,28 @@ height:18px !important;
   font-size:var(--t-b-1-size); font-weight:var(--t-b-1-weight); line-height:var(--t-b-1-line-height);
   text-transform: uppercase;
   cursor: pointer;
-  line-height: 0;
   transition: background-color 0.3s, color 0.3s, border 0.3s;
   width:159px;
 }
-.load-more-btn-fb:hover {
+
+.blog-section-container .load-more-btn-fb:hover {
   background-color: var(--hovered_button_label);
   color: var(--hovered_button_text_color);
   border: 1px solid var(--hovered_button_text_color);
 }
+
+/* Blog posts load more button using primary-button snippet */
+.blog-section-container .blog-posts-load-more-btn {
+  min-width: 200px;
+  width: auto !important;
+}
+
+.blog-section-container .blog-posts-load-more-btn,
+.blog-section-container .blog-posts-load-more-btn * {
+  cursor: pointer !important;
+  pointer-events: auto !important;
+}
+
 .load-more-text-container {
   position: relative;
   display: inline-block;

--- a/assets/blog-grid.js
+++ b/assets/blog-grid.js
@@ -1,6 +1,4 @@
 document.addEventListener('DOMContentLoaded', function () {
-  const loadMoreBtn = document.getElementById('load-more-btn-fb');
-
   function updateLastVisibleMargin() {
     // Remove margin override from all articles
     document.querySelectorAll('.blog-article').forEach((article) => {
@@ -18,22 +16,21 @@ document.addEventListener('DOMContentLoaded', function () {
 
   updateLastVisibleMargin(); // Call on initial load
 
-  if (loadMoreBtn) {
-    loadMoreBtn.addEventListener('mouseenter', function () {
-      loadMoreBtn.classList.remove('animate');
-      void loadMoreBtn.offsetWidth; // Trigger reflow
-      loadMoreBtn.classList.add('animate');
-    });
+  // Use parent container approach to handle clicks
+  const loadMoreContainer = document.querySelector('.blog-section-container .load-more-btn-fb-container');
+  if (loadMoreContainer) {
+    const loadMoreBtn =
+      loadMoreContainer.querySelector('#load-more-btn-fb') ||
+      loadMoreContainer.querySelector('button') ||
+      loadMoreContainer.querySelector('a');
 
-    loadMoreBtn.addEventListener('animationend', function (e) {
-      if (e.target.classList.contains('load-more-text-hover')) {
-        loadMoreBtn.classList.remove('animate');
-      }
-    });
+    // Add click handler to the container to catch all clicks
+    loadMoreContainer.addEventListener('click', function (e) {
+      e.preventDefault();
+      e.stopPropagation();
 
-    loadMoreBtn.addEventListener('click', function () {
       const hiddenArticles = document.querySelectorAll('.blog-article.hidden-articles');
-      const articlesPerLoad = parseInt(loadMoreBtn.getAttribute('data-articles-per-load')) || 3;
+      const articlesPerLoad = parseInt((loadMoreBtn && loadMoreBtn.dataset.articlesPerLoad) || '3') || 3;
 
       for (let i = 0; i < Math.min(articlesPerLoad, hiddenArticles.length); i++) {
         const article = hiddenArticles[i];
@@ -54,11 +51,8 @@ document.addEventListener('DOMContentLoaded', function () {
 
       const remainingHidden = document.querySelectorAll('.blog-article.hidden-articles');
       if (remainingHidden.length === 0) {
-        loadMoreBtn.style.display = 'none';
+        loadMoreContainer.style.display = 'none';
       }
-
-      const remaining = remainingHidden.length;
-      loadMoreBtn.setAttribute('data-remaining', remaining);
 
       updateLastVisibleMargin(); // Update the last visible article
     });

--- a/sections/blog-grid.liquid
+++ b/sections/blog-grid.liquid
@@ -29,12 +29,20 @@
     {% assign remaining_articles = articles_count | minus: articles_limit %}
     {% if remaining_articles > 0 %}
       <div class="load-more-btn-fb-container">
-        <button id="load-more-btn-fb" class="load-more-btn-fb">
-          <span class="load-more-text-container">
-            <span class="load-more-text load-more-text-margin">LOAD MORE &nbsp;</span>
-            <span class="load-more-text-hover">&nbsp;LOAD MORE</span>
-          </span>
-        </button>
+        {% render 'primary-button',
+          button_text: 'LOAD MORE',
+          button_url: '',
+          button_type: 'button',
+          button_id: 'load-more-btn-fb',
+          primary_class: 'blog-posts-load-more-btn',
+          data_attributes: 'data-articles-per-load="{{ section.settings.articles_per_page | default: 3 }}"',
+          button_font_size: 'var(--t-b-1-size)',
+          font_weight: 'var(--t-b-1-weight)',
+          button_line_height: 'var(--t-b-1-line-height)',
+          mobile_font_size: 'var(--tm-b-2-size)',
+          mobile_font_weight: 'var(--t-b-2-weight)',
+          mobile_line_height: 'var(--tm-b-2-line-height)'
+        %}
       </div>
     {% endif %}
   </div>

--- a/sections/featured-blog.liquid
+++ b/sections/featured-blog.liquid
@@ -362,6 +362,19 @@
        margin-bottom: 40px;
        display: flex;
        justify-content: end;
+       cursor: pointer;
+     }
+
+     /* Featured blog load more button styles */
+     .featured-blog-load-more-btn {
+       min-width: 159px;
+       width: auto !important;
+     }
+
+     .featured-blog-load-more-btn,
+     .featured-blog-load-more-btn * {
+       cursor: pointer !important;
+       pointer-events: auto !important;
      }
 
      .featured-blog-grid.list-view .featured-blog-card-title{
@@ -557,6 +570,11 @@
        .load-more-btn-fb-text-hover {
          font-size: var(--t-b-1-size);
        }
+
+       /* Featured blog load more button desktop styles */
+       .featured-blog-load-more-btn {
+         min-width: 200px;
+       }
      }
 
      /* Ensure the container doesn’t clip anything */
@@ -623,20 +641,21 @@
       id="archiveContainer"
       aria-live="polite"
       aria-label="Blog articles"
-      data-post-limit="{{ section.settings.post_limit }}"
+      data-post-limit="3"
       data-total-posts="{% assign blog_handle = section.settings.blog %}{% if blog_handle != blank %}{{ blogs[blog_handle].articles.size }}{% else %}0{% endif %}"
     >
       <!-- Separator before container (only visible in list view) -->
       <div class="list-separator"></div>
 
       {% assign blog_handle = section.settings.blog %}
-      {% assign post_limit = section.settings.post_limit | default: 3 %}
+      {% assign initial_display = 3 %}
+      {% assign load_more_increment = section.settings.post_limit | default: 6 %}
       {% if blog_handle != blank and blogs[blog_handle].articles.size > 0 %}
         {% for article in blogs[blog_handle].articles %}
           <article
             aria-labelledby="article-title-{{ forloop.index0 }}"
             class="blog-article-fb"
-            {% if forloop.index > post_limit %}
+            {% if forloop.index > initial_display %}
               style="display: none;"
             {% endif %}
           >
@@ -721,7 +740,7 @@
         {% endfor %}
       {% else %}
         {% comment %} Show placeholder blog articles when no blog is selected {% endcomment %}
-        {% for i in (1..post_limit) %}
+        {% for i in (1..3) %}
           {%- assign placeholder_image = 'collection-1' -%}
           <article
             aria-labelledby="placeholder-article-title-{{ forloop.index0 }}"
@@ -783,13 +802,15 @@
         {% endfor %}
       {% endif %}
     </div>
-    {% if blog_handle != blank and blogs[blog_handle].articles.size > section.settings.post_limit %}
+    {% if blog_handle != blank and blogs[blog_handle].articles.size > 3 %}
       <div class="load-more-btn-fb-container">
         {% render 'primary-button',
           button_text: 'LOAD MORE',
           button_url: '',
-          primary_class: 'load-more-btn-fb',
-          data_attributes: 'data-increment="6"',
+          button_type: 'button',
+          button_id: 'featured-blog-load-more',
+          primary_class: 'featured-blog-load-more-btn',
+          data_attributes: 'data-articles-per-load="{{ section.settings.post_limit | default: 6 }}"',
           button_font_size: 'var(--t-b-1-size)',
           font_weight: 'var(--t-b-1-weight)',
           button_line_height: 'var(--t-b-1-line-height)',
@@ -848,7 +869,7 @@
     const slider = document.querySelector('.toggle-slider');
     const container = document.getElementById('archiveContainer');
     const buttons = [gridBtn, listBtn];
-    const loadMoreBtn = document.querySelector('.load-more-btn-fb');
+    const loadMoreBtn = document.getElementById('featured-blog-load-more');
 
     // Featured Blog Fade-Up Animation
     const blogArticles = document.querySelectorAll('.blog-article-fb');
@@ -885,16 +906,32 @@
       observer.observe(article);
     });
 
-    // Load more functionality
-    if (loadMoreBtn) {
-      const increment = parseInt(loadMoreBtn.dataset.increment || '6', 10);
-      const postLimit = parseInt(container.dataset.postLimit || '5', 10);
+    // Load more functionality - use specific selector for featured blog section
+    const loadMoreContainer = document.querySelector('.featured-blog-section .load-more-btn-fb-container');
+    if (loadMoreContainer) {
+      const loadMoreBtnInside =
+        loadMoreContainer.querySelector('#featured-blog-load-more') ||
+        loadMoreContainer.querySelector('button') ||
+        loadMoreContainer.querySelector('a');
+
+      const incrementValue = (loadMoreBtnInside && loadMoreBtnInside.dataset.articlesPerLoad) || '6';
+      let increment = parseInt(incrementValue, 10);
+      // Fallback if increment is NaN
+      if (isNaN(increment)) {
+        increment = 6;
+      }
+      const postLimit = parseInt(container.dataset.postLimit || '3', 10);
       let currentlyVisible = postLimit;
 
-      loadMoreBtn.addEventListener('click', function (e) {
-        e.preventDefault(); // Prevent any default button behavior
+      // Add click handler to the parent container to catch all clicks
+      loadMoreContainer.addEventListener('click', function (e) {
+        e.preventDefault();
+        e.stopPropagation();
+
         const blogArticles = document.querySelectorAll('#archiveContainer .blog-article-fb');
-        const endIndex = Math.min(currentlyVisible + increment, blogArticles.length);
+        const safeIncrement = isNaN(increment) ? 6 : increment;
+        const endIndex = Math.min(currentlyVisible + safeIncrement, blogArticles.length);
+
         for (let i = currentlyVisible; i < endIndex; i++) {
           if (blogArticles[i]) {
             blogArticles[i].style.display = '';
@@ -913,8 +950,9 @@
           }
         }
         currentlyVisible = endIndex;
+
         if (currentlyVisible >= blogArticles.length) {
-          loadMoreBtn.parentElement.style.display = 'none';
+          loadMoreContainer.style.display = 'none';
         }
       });
 
@@ -925,8 +963,8 @@
         });
       };
 
-      gridBtn.addEventListener('click', updateVisibilityAfterViewChange);
-      listBtn.addEventListener('click', updateVisibilityAfterViewChange);
+      if (gridBtn) gridBtn.addEventListener('click', updateVisibilityAfterViewChange);
+      if (listBtn) listBtn.addEventListener('click', updateVisibilityAfterViewChange);
     }
 
     function updateSliderPos(isList) {
@@ -1005,9 +1043,10 @@
     {
       "type": "range",
       "id": "post_limit",
-      "label": "Number of Posts to Display",
+      "label": "Posts to Load Per Click",
+      "info": "Number of additional posts to show when 'Load More' is clicked. Initial display is always 3 posts.",
       "default": 6,
-      "min": 3,
+      "min": 1,
       "max": 20,
       "step": 1
     },
@@ -1024,7 +1063,7 @@
       "settings": {
         "enabled": true,
         "heading": "Featured Blogs",
-        "post_limit": 3
+        "post_limit": 6
       }
     }
   ]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refactors blog and featured blog “Load More” to use primary-button with scoped styles and container-based click handling, adjustable per-click counts, and improved animations/visibility.
> 
> - **Blog Grid**:
>   - Replace inline button with `primary-button` (`sections/blog-grid.liquid`) and add `data-articles-per-load`.
>   - Delegate clicks to `.load-more-btn-fb-container` and read per-load from dataset (`assets/blog-grid.js`); hide container when exhausted; maintain fade-up animations and last-visible marker.
>   - Scope button styles to `.blog-section-container`; add mobile/desktop min-widths and pointer behavior (`assets/blog-grid.css`).
> - **Featured Blogs**:
>   - Fix initial render to 3 posts (`data-post-limit="3"`, `initial_display = 3`); placeholders loop to 3.
>   - Swap to `primary-button` with id `featured-blog-load-more` and `data-articles-per-load` (`sections/featured-blog.liquid`).
>   - Delegate clicks to parent container; parse increment safely; hide container when done; guard view-toggle listeners.
>   - Add `.featured-blog-load-more-btn` styles with min-widths and pointer behavior; minor responsive tweaks.
>   - Schema: rename `post_limit` label to "Posts to Load Per Click", add info, set min 1, default/preset 6.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ccc859f53a7388e3094fb01ff13c11e999f68586. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->