### PR TITLE
button fixed

### DIFF
--- a/assets/blog-grid.css
+++ b/assets/blog-grid.css
@@ -47,8 +47,9 @@ height:18px !important;
 
 /* Blog posts load more button mobile */
 .blog-section-container .blog-posts-load-more-btn {
-  min-width: 104px;
+  min-width: auto !important;
   width: auto !important;
+  max-width: fit-content !important;
 }
     .blog_highlight-tag{
       font-size:var(--tm-h-3-size) !important;
@@ -209,8 +210,9 @@ height:18px !important;
 
 /* Blog posts load more button using primary-button snippet */
 .blog-section-container .blog-posts-load-more-btn {
-  min-width: 200px;
+  min-width: auto !important;
   width: auto !important;
+  max-width: fit-content !important;
 }
 
 .blog-section-container .blog-posts-load-more-btn,

--- a/sections/featured-blog.liquid
+++ b/sections/featured-blog.liquid
@@ -367,8 +367,10 @@
 
      /* Featured blog load more button styles */
      .featured-blog-load-more-btn {
-       min-width: 159px;
+       min-width: auto !important;
        width: auto !important;
+       max-width: fit-content !important;
+
      }
 
      .featured-blog-load-more-btn,
@@ -571,10 +573,7 @@
          font-size: var(--t-b-1-size);
        }
 
-       /* Featured blog load more button desktop styles */
-       .featured-blog-load-more-btn {
-         min-width: 200px;
-       }
+
      }
 
      /* Ensure the container doesn’t clip anything */


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Make blog and featured blog “Load More” buttons auto-size by removing fixed min-widths and capping with fit-content.
> 
> - **Styles**:
>   - **Blog Grid (`assets/blog-grid.css`)**:
>     - `blog-posts-load-more-btn`: replace fixed `min-width` with `min-width: auto !important`; keep `width: auto !important`; add `max-width: fit-content !important` for mobile and primary-button variant.
>   - **Featured Blog (`sections/featured-blog.liquid`)**:
>     - `featured-blog-load-more-btn`: replace fixed `min-width` with `min-width: auto !important`; keep `width: auto !important`; add `max-width: fit-content !important`.
>     - Remove desktop rule that enforced `min-width: 200px`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd100478af36950f22a68f2b616790d43ab7e041. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->