### PR TITLE
search results page fixed

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -1783,7 +1783,7 @@ details[open] > .share-button__fallback {
 .customer .field input:not(:placeholder-shown) ~ label,
 .customer .field input:-webkit-autofill ~ label {
   font-size: 1rem;
-  top: calc(var(--inputs-border-width) + 0.5rem);
+  top: calc(var(--inputs-border-width) + 0rem);
   left: calc(var(--inputs-border-width) + 2rem);
   letter-spacing: 0.04rem;
 }

--- a/sections/main-collection-product-grid.liquid
+++ b/sections/main-collection-product-grid.liquid
@@ -24,6 +24,13 @@
     row-gap: var(--grid-vertical-gap) !important;
   }
 
+  /* Desktop columns - use section setting */
+  @media screen and (min-width: 990px) {
+    .collection-page-wrapper .product-grid {
+      grid-template-columns: repeat({{ section.settings.columns_desktop | default: 3 }}, 1fr) !important;
+    }
+  }
+
   .filters-container {
     padding-left: {{ settings.side_space }}px !important;
     padding-right: {{ settings.side_space }}px !important;
@@ -128,6 +135,19 @@
       "id": "show_secondary_image",
       "default": false,
       "label": "Show secondary image on hover"
+    },
+    {
+      "type": "header",
+      "content": "Desktop Layout"
+    },
+    {
+      "type": "range",
+      "id": "columns_desktop",
+      "min": 1,
+      "max": 6,
+      "step": 1,
+      "default": 3,
+      "label": "Desktop columns"
     },
     {
       "type": "header",

--- a/sections/main-search.liquid
+++ b/sections/main-search.liquid
@@ -2,41 +2,58 @@
 {{ 'component-card.css' | asset_url | stylesheet_tag }}
 {{ 'component-price.css' | asset_url | stylesheet_tag }}
 {{ 'component-search.css' | asset_url | stylesheet_tag }}
+{{ 'scroll-animations.css' | asset_url | stylesheet_tag }}
+{{ 'main-collection-product-grid.css' | asset_url | stylesheet_tag }}
 
 {%- if section.settings.enable_filtering or section.settings.enable_sorting -%}
   {{ 'component-facets.css' | asset_url | stylesheet_tag }}
   <script src="{{ 'facets.js' | asset_url }}" defer="defer"></script>
 {%- endif -%}
 
-{% if section.settings.image_shape == 'blob' %}
-  {{ 'mask-blobs.css' | asset_url | stylesheet_tag }}
-{%- endif -%}
-
+<script src="{{ 'scroll-animations.js' | asset_url }}" defer="defer"></script>
 <script src="{{ 'main-search.js' | asset_url }}" defer="defer"></script>
 
 <style>
+  :root {
+    --filters-drawer-speed: {{ section.settings.filters_drawer_animation_speed | default: settings.filters_drawer_animation_speed | default: 0.6 }}s !important;
+  }
+
+  /* Mobile spacing - use global settings */
   .template-search {
-    padding-top: var(--sections-spacing-top) !important;
-    padding-bottom: var(--sections-spacing-bottom) !important;
+    padding-top: calc(var(--sections-spacing-top) + 30px) !important;
+    padding-bottom: calc(var(--sections-spacing-bottom) + 0px) !important;
+    min-height: 40vh;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
   }
 
-  .template-search__header {
+  /* Desktop spacing - use global settings */
+  @media screen and (min-width: 750px) {
+    .template-search {
+      padding-top: calc(var(--sections-spacing-top) + 30px) !important;
+      padding-bottom: calc(var(--sections-spacing-bottom) + 0px) !important;
+    }
+  }
+
+  .template-search__head1 {
     margin-bottom: 3rem;
+
   }
 
-  .bb-search-field::after
-  {
+  .bb-search-field::after {
     box-shadow: none;
   }
 
-  .bb-search-field:hover.bb-search-field:after
-  {
+  .bb-search-field:hover.bb-search-field:after {
     box-shadow: none;
   }
 
   .template-search__search {
     margin: 0 auto 3.5rem;
     max-width: 74.1rem;
+    padding-left: {{ settings.side_space }}px;
+    padding-right: {{ settings.side_space }}px;
   }
 
   .template-search__search .search {
@@ -50,8 +67,9 @@
   .bb-field__input:focus {
     box-shadow: none;
   }
+
   @media screen and (min-width: 750px) {
-    .template-search__header {
+    .template-search__head1 {
       margin-bottom: 5rem;
     }
   }
@@ -63,6 +81,7 @@
   .submit-wrapper {
     color: var(--button_label);
     padding: 0px 10px;
+    margin-right: 10px;
     background-color: var(--button);
     border-radius: {{ settings.buttons_radius }}px;
   }
@@ -80,10 +99,9 @@
 
   .search__input {
     flex: 1;
-    padding-right: 10rem; /* Make more space for both buttons */
+    padding-right: 10rem;
   }
 
-  /* Adjust input text position closer to the bottom line */
   .bb-field__input.search__input.field__input {
     padding-bottom: 0.5rem;
     line-height: 1.2;
@@ -104,11 +122,10 @@
   }
 
   .reset__button {
-    right: -0.5rem; /* Position reset button to the right of submit button */
+    right: -0.5rem;
     padding: 0.5rem;
   }
 
-  /* Always show reset button */
   .reset__button.hidden {
     display: block !important;
     visibility: visible !important;
@@ -116,52 +133,52 @@
   }
 
   .search__button {
-    right: 2.75rem; /* Position submit button with space from right edge */
+    right: 2.75rem;
     z-index: 0;
   }
 
-  /* Fix for card-product images in search results */
-  #product-grid .card-wrapper .image-config {
-    object-fit: cover !important;
+  /* Apply same container padding as collection grid */
+  .template-search .products-container {
+    padding-left: {{ settings.side_space }}px !important;
+    padding-right: {{ settings.side_space }}px !important;
   }
 
-  #product-grid .card-wrapper .product-card-height {
-    position: relative;
-    overflow: hidden;
+  /* Mobile grid spacing - use global settings */
+  .template-search .product-grid {
+    column-gap: {{ settings.horizontal_space_mobile | default: 8 }}px !important;
+    row-gap: {{ settings.vertical_space_mobile | default: 45 }}px !important;
   }
 
-  #product-grid .card-wrapper img {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-  }
-
-  /* Disable height changes on mobile hover in search results */
-  @media only screen and (max-width: 600px) {
-    #product-grid .card-wrapper:hover .product-card-height {
-      height: 270px !important;
-      transition: none !important;
-    }
-
-    #product-grid .card-wrapper .product-card-height {
-      height: 270px !important;
+  /* Desktop grid spacing - use global settings */
+  @media screen and (min-width: 750px) {
+    .template-search .product-grid {
+      column-gap: {{ settings.horizontal_space_desktop | default: 8 }}px !important;
+      row-gap: {{ settings.vertical_space_desktop | default: 45 }}px !important;
     }
   }
 
-  /* Additional touch device detection */
-  @media (hover: none) and (pointer: coarse) {
-    #product-grid .card-wrapper:hover .product-card-height,
-    #product-grid .group:hover .product-card-height,
-    #product-grid .card-wrapper .product-card-height {
-      height: 270px !important;
-      transition: none !important;
+  /* Desktop columns - use section setting */
+  @media screen and (min-width: 990px) {
+    .template-search .product-grid {
+      grid-template-columns: repeat({{ section.settings.columns_desktop | default: 4 }}, 1fr) !important;
     }
+  }
 
-    /* Prevent any height changes on touch */
-    #product-grid .card-wrapper:active .product-card-height,
-    #product-grid .card-wrapper:focus .product-card-height {
-      height: 270px !important;
-    }
+
+
+  .template-search .facets-wrapper {
+    padding-left: {{ settings.side_space }}px !important;
+    padding-right: {{ settings.side_space }}px !important;
+  }
+
+  .template-search #main-search-filters {
+    padding-left: {{ settings.side_space }}px !important;
+    padding-right: {{ settings.side_space }}px !important;
+  }
+
+  .template-search .facets-vertical-sort {
+    padding-left: {{ settings.side_space }}px !important;
+    padding-right: {{ settings.side_space }}px !important;
   }
 
   /* Fix mobile sort dropdown visibility */
@@ -171,13 +188,11 @@
     position: absolute !important;
   }
 
-  /* Ensure parent containers don't hide the dropdown */
   .facets-wrapper,
   .mobile-facets__wrapper,
   #main-search-filters {
     overflow: visible !important;
     position: relative !important;
-   /* z-index: 100 !important; */
   }
 </style>
 
@@ -201,9 +216,9 @@
   }
 {%- endstyle -%}
 
-{% paginate search.results by 24 %}
+{% paginate search.results by section.settings.products_per_page %}
   <div class="template-search{% unless search.performed and search.results_count > 0 %} template-search--empty{% endunless %} section-{{ section.id }}-padding color-{{ section.settings.color_scheme }}">
-    <div class="template-search__header page-width{% if settings.animations_reveal_on_scroll %} scroll-trigger animate--fade-in{% endif %}">
+    <div class="template-search__head1 {% if settings.animations_reveal_on_scroll %} scroll-trigger animate--fade-in{% endif %}">
       <h1 class="h2 center">
         {%- if search.performed -%}
           {{- 'templates.search.title' | t -}}
@@ -274,6 +289,17 @@
           </predictive-search>
         {%- endif -%}
       </div>
+
+      {%- unless search.performed -%}
+        <div class="no-search-message" style="text-align: center; padding: 0px 20px; margin-top: 40px;">
+          <h2
+            style="font-family: var(--font-heading-family); font-style: var(--font-heading-style); font-weight: var(--font-heading-weight); font-size: calc(var(--font-heading-scale) * 3.5rem); color: var(--text); text-transform: uppercase; letter-spacing: calc(var(--font-heading-scale) * 0.06rem);"
+          >
+            You searched for no products...
+          </h2>
+        </div>
+      {%- endunless -%}
+
       {%- if search.performed -%}
         {%- unless section.settings.enable_filtering or section.settings.enable_sorting -%}
           {%- if search.results_count > 0 -%}
@@ -288,73 +314,12 @@
       {%- endif -%}
     </div>
     {%- if search.performed -%}
-      {%- if section.settings.enable_sorting
-        and section.settings.filter_type == 'vertical'
-        and search.filters != empty
-      -%}
-        <facet-filters-form class="facets facets-vertical-sort page-width small-hide">
-          <form class="facets-vertical-form" id="FacetSortForm">
-            <div class="facet-filters sorting caption">
-              <div class="facet-filters__field">
-                <h2 class="facet-filters__label caption-large text-body">
-                  <label for="SortBy">{{ 'products.facets.sort_by_label' | t }}</label>
-                </h2>
-                <div class="select">
-                  {%- assign sort_by = search.sort_by | default: search.default_sort_by -%}
-                  <select
-                    name="sort_by"
-                    class="facet-filters__sort select__select caption-large"
-                    id="SortBy"
-                    aria-describedby="a11y-refresh-page-message"
-                  >
-                    {%- for option in search.sort_options -%}
-                      <option
-                        value="{{ option.value | escape }}"
-                        {% if option.value == sort_by %}
-                          selected="selected"
-                        {% endif %}
-                      >
-                        {{ option.name | escape }}
-                      </option>
-                    {%- endfor -%}
-                  </select>
-                  <span class="svg-wrapper">
-                    {{- 'icon-caret.svg' | inline_asset_content -}}
-                  </span>
-                </div>
-              </div>
-            </div>
-
-            <div class="product-count-vertical light" role="status">
-              <h2 class="product-count__text text-body">
-                <span id="ProductCountDesktop">
-                  {%- if search.results_count -%}
-                    {{ 'templates.search.results_with_count' | t: terms: search.terms, count: search.results_count }}
-                  {%- elsif search.products_count == search.all_products_count -%}
-                    {{ 'products.facets.product_count_simple' | t: count: search.products_count }}
-                  {%- else -%}
-                    {{
-                      'products.facets.product_count'
-                      | t: product_count: search.products_count, count: search.all_products_count
-                    }}
-                  {%- endif -%}
-                </span>
-              </h2>
-              {%- render 'loading-spinner' -%}
-            </div>
-          </form>
-        </facet-filters-form>
-      {%- endif -%}
-      <div
-        {% if section.settings.filter_type == 'vertical' %}
-          class="facets-vertical page-width"
-        {% endif %}
-      >
+      <div>
         {%- if search.filters != empty -%}
           {%- if section.settings.enable_filtering or section.settings.enable_sorting -%}
             <aside
               aria-labelledby="verticalTitle"
-              class="facets-wrapper{% unless section.settings.enable_filtering %} facets-wrapper--no-filters{% endunless %}{% if section.settings.filter_type != 'vertical' %} page-width{% endif %}"
+              class="facets-wrapper{% unless section.settings.enable_filtering %} facets-wrapper--no-filters{% endunless %}"
               id="main-search-filters"
               data-id="{{ section.id }}"
             >
@@ -362,7 +327,7 @@
                 results: search,
                 enable_filtering: section.settings.enable_filtering,
                 enable_sorting: section.settings.enable_sorting,
-                filter_type: section.settings.filter_type,
+                filter_type: 'horizontal',
                 paginate: paginate,
                 facet_icon_size: section.settings.facet_icon_size,
                 facet_icon_thickness: section.settings.facet_icon_thickness,
@@ -375,7 +340,7 @@
         <div class="product-grid-container" id="ProductGridContainer">
           {%- if search.results.size == 0 and search.filters != empty -%}
             <div
-              class="template-search__results collection collection--empty{% if section.settings.filter_type != 'vertical' %} page-width{% endif %}"
+              class="template-search__results collection collection--empty"
               id="product-grid"
               data-id="{{ section.id }}"
             >
@@ -392,47 +357,36 @@
               </div>
             </div>
           {%- else -%}
-            <div
-              class="template-search__results collection{% if section.settings.filter_type != 'vertical' %} page-width{% endif %}"
-              id="product-grid"
-              data-id="{{ section.id }}"
-            >
-              <div class="loading-overlay gradient"></div>
-              <ul
-                class="grid product-grid  grid--{{ section.settings.columns_mobile }}-col-tablet-down grid--{{ section.settings.columns_desktop }}-col-desktop"
-                role="list"
+            <div class="products-container">
+              <div
+                class="product-grid product-grid-animated scroll-fade-stagger mobile-columns-{{ section.settings.columns_mobile }}"
+                id="product-grid"
+                data-id="{{ section.id }}"
               >
-                {%- assign skip_card_product_styles = false -%}
+                <div class="loading-overlay gradient"></div>
                 {%- for item in search.results -%}
-                  {% assign lazy_load = false %}
-                  {%- if forloop.index > 2 -%}
-                    {%- assign lazy_load = true -%}
-                  {%- endif -%}
                   {%- case item.object_type -%}
                     {%- when 'product' -%}
-                      <li
-                        class="grid__item{% if settings.animations_reveal_on_scroll %} scroll-trigger animate--slide-in{% endif %}"
-                        {% if settings.animations_reveal_on_scroll %}
-                          data-cascade
-                        {% endif %}
+                      <div
+                        class="product-card-item scroll-fade-trigger scroll-fade-up"
+                        data-animation-index="{{ forloop.index0 }}"
                       >
-                        {% render 'card-product',
+                        {%
+                          render 'card-product',
                           card_product: item,
-                          media_aspect_ratio: section.settings.image_ratio,
-                          image_shape: section.settings.image_shape,
                           show_secondary_image: section.settings.show_secondary_image,
-                          show_vendor: section.settings.show_vendor,
-                          show_rating: section.settings.show_rating,
-                          lazy_load: lazy_load,
-                          skip_styles: skip_card_product_styles
+                          lazy_load: forloop.index > 2,
+                          section_id: section.id
                         %}
-                        {%- assign skip_card_product_styles = true -%}
-                      </li>
+                      </div>
                   {%- endcase -%}
                 {%- endfor -%}
-              </ul>
+              </div>
+
               {%- if paginate.pages > 1 -%}
-                {% render 'pagination', paginate: paginate %}
+                <div class="pagination-wrapper">
+                  {% render 'pagination', paginate: paginate, anchor: '' %}
+                </div>
               {%- endif -%}
             </div>
           {%- endif -%}
@@ -441,9 +395,6 @@
     {%- endif -%}
   </div>
 {% endpaginate %}
-{% if section.settings.image_shape == 'arch' %}
-  {{ 'mask-arch.svg' | inline_asset_content }}
-{%- endif -%}
 
 {% schema %}
 {
@@ -452,10 +403,33 @@
   "class": "section",
   "settings": [
     {
+      "type": "range",
+      "id": "products_per_page",
+      "min": 8,
+      "max": 48,
+      "step": 4,
+      "default": 8,
+      "label": "Products per page"
+    },
+    {
       "type": "color_scheme",
       "id": "color_scheme",
       "label": "t:sections.all.colors.label",
       "default": "scheme-1"
+    },
+    {
+      "type": "header",
+      "content": "Product Display"
+    },
+    {
+      "type": "checkbox",
+      "id": "show_secondary_image",
+      "default": false,
+      "label": "Show secondary image on hover"
+    },
+    {
+      "type": "header",
+      "content": "Desktop Layout"
     },
     {
       "type": "range",
@@ -463,160 +437,55 @@
       "min": 1,
       "max": 6,
       "step": 1,
-      "default": 4,
-      "label": "t:sections.main-search.settings.columns_desktop.label"
+      "default": 3,
+      "label": "Desktop columns"
+    },
+    {
+      "type": "header",
+      "content": "Mobile Layout"
     },
     {
       "type": "select",
       "id": "columns_mobile",
-      "default": "2",
-      "label": "t:sections.main-search.settings.columns_mobile.label",
       "options": [
         {
           "value": "1",
-          "label": "t:sections.main-search.settings.columns_mobile.options__1.label"
+          "label": "1 column"
         },
         {
           "value": "2",
-          "label": "t:sections.main-search.settings.columns_mobile.options__2.label"
+          "label": "2 columns"
         }
-      ]
+      ],
+      "default": "1",
+      "label": "Mobile columns"
     },
     {
       "type": "header",
-      "content": "t:sections.main-search.settings.header__1.content"
-    },
-    {
-      "type": "select",
-      "id": "image_ratio",
-      "options": [
-        {
-          "value": "adapt",
-          "label": "t:sections.main-search.settings.image_ratio.options__1.label"
-        },
-        {
-          "value": "portrait",
-          "label": "t:sections.main-search.settings.image_ratio.options__2.label"
-        },
-        {
-          "value": "square",
-          "label": "t:sections.main-search.settings.image_ratio.options__3.label"
-        }
-      ],
-      "default": "adapt",
-      "label": "t:sections.main-search.settings.image_ratio.label"
-    },
-    {
-      "type": "select",
-      "id": "image_shape",
-      "options": [
-        {
-          "value": "default",
-          "label": "t:sections.all.image_shape.options__1.label"
-        },
-        {
-          "value": "arch",
-          "label": "t:sections.all.image_shape.options__2.label"
-        },
-        {
-          "value": "blob",
-          "label": "t:sections.all.image_shape.options__3.label"
-        },
-        {
-          "value": "chevronleft",
-          "label": "t:sections.all.image_shape.options__4.label"
-        },
-        {
-          "value": "chevronright",
-          "label": "t:sections.all.image_shape.options__5.label"
-        },
-        {
-          "value": "diamond",
-          "label": "t:sections.all.image_shape.options__6.label"
-        },
-        {
-          "value": "parallelogram",
-          "label": "t:sections.all.image_shape.options__7.label"
-        },
-        {
-          "value": "round",
-          "label": "t:sections.all.image_shape.options__8.label"
-        }
-      ],
-      "default": "default",
-      "label": "t:sections.all.image_shape.label"
-    },
-    {
-      "type": "checkbox",
-      "id": "show_secondary_image",
-      "default": false,
-      "label": "t:sections.main-search.settings.show_secondary_image.label"
-    },
-    {
-      "type": "checkbox",
-      "id": "show_vendor",
-      "default": false,
-      "label": "t:sections.main-search.settings.show_vendor.label"
-    },
-    {
-      "type": "checkbox",
-      "id": "show_rating",
-      "default": false,
-      "label": "t:sections.main-search.settings.show_rating.label",
-      "info": "t:sections.main-search.settings.show_rating.info"
-    },
-    {
-      "type": "header",
-      "content": "t:sections.main-collection-product-grid.settings.header__1.content"
+      "content": "Filtering and sorting"
     },
     {
       "type": "checkbox",
       "id": "enable_filtering",
       "default": true,
-      "label": "t:sections.main-collection-product-grid.settings.enable_filtering.label",
-      "info": "t:sections.main-collection-product-grid.settings.enable_filtering.info"
+      "label": "Enable filtering"
     },
     {
-      "type": "select",
-      "id": "filter_type",
-      "options": [
-        {
-          "value": "horizontal",
-          "label": "t:sections.main-collection-product-grid.settings.filter_type.options__1.label"
-        },
-        {
-          "value": "vertical",
-          "label": "t:sections.main-collection-product-grid.settings.filter_type.options__2.label"
-        },
-        {
-          "value": "drawer",
-          "label": "t:sections.main-collection-product-grid.settings.filter_type.options__3.label"
-        }
-      ],
-      "default": "horizontal",
-      "label": "t:sections.main-collection-product-grid.settings.filter_type.label"
+      "type": "range",
+      "id": "filters_drawer_animation_speed",
+      "min": 0.1,
+      "max": 2.0,
+      "step": 0.1,
+      "unit": "s",
+      "label": "Filters Drawer Animation Speed",
+      "default": 0.6,
+      "info": "Speed of the mobile filters drawer open/close animation (in seconds)."
     },
     {
       "type": "checkbox",
       "id": "enable_sorting",
       "default": true,
-      "label": "t:sections.main-collection-product-grid.settings.enable_sorting.label"
-    },
-    {
-      "type": "header",
-      "content": "t:sections.main-search.settings.header__2.content"
-    },
-    {
-      "type": "checkbox",
-      "id": "article_show_date",
-      "default": true,
-      "label": "t:sections.main-search.settings.article_show_date.label"
-    },
-    {
-      "type": "checkbox",
-      "id": "article_show_author",
-      "default": false,
-      "label": "t:sections.main-search.settings.article_show_author.label"
+      "label": "Enable sorting"
     },
     {
       "type": "header",

--- a/snippets/facets.liquid
+++ b/snippets/facets.liquid
@@ -37,8 +37,15 @@
       <span class="mx-2 facets-text-color">/</span>
       <h1 class="!text-[1.6rem] !font-light uppercase facets-text-color">
         <span class="visually-hidden">{{ 'sections.collection_template.title' | t }}: </span>
-        {{- collection.title | escape -}}
+        {%- if results.terms -%}
+          Search Results
+        {%- else -%}
+          {{- collection.title | escape -}}
+        {%- endif -%}
       </h1>
+      {%- if results.terms and results.results_count -%}
+        <span class="mx-2 facets-text-color !text-[1.6rem] !font-light">[{{ results.results_count }}]</span>
+      {%- endif -%}
     </div>
   {% endif %}
   {%- if filter_type == 'vertical' or filter_type == 'horizontal' -%}
@@ -1852,73 +1859,33 @@
 
   // Clear all filters function
   window.clearAllFilters = function () {
-    // Uncheck all filter checkboxes
-    document.querySelectorAll('input[type="checkbox"][name^="filter."]').forEach((input) => {
-      input.checked = false;
-    });
-
-    // Clear all price range inputs
-    document.querySelectorAll('input[type="number"]').forEach((input) => {
-      input.value = '';
-    });
-
-    // Reset sort to default
-    const sortInputs = document.querySelectorAll('input[name="sort_by"]');
-    sortInputs.forEach((input) => {
-      input.checked = false;
-    });
-
-    // Hide the tags container immediately
-    const tagsContainer = document.querySelector('.active-filters-tags-container');
-    if (tagsContainer) {
-      tagsContainer.style.display = 'none';
-    }
-
-    // Apply the filter changes
-    if (typeof window.applyFiltersAjax === 'function') {
-      window.applyFiltersAjax();
+    // For search pages, preserve the search query
+    const searchInput = document.querySelector('input[name="q"]');
+    const searchQuery = searchInput ? searchInput.value : '';
+    
+    // Navigate to base URL with search query but no filters
+    if (searchQuery) {
+      // Search page - keep the search term but clear filters
+      window.location.href = '{{ routes.search_url }}?q=' + encodeURIComponent(searchQuery) + '&options%5Bprefix%5D=last';
     } else {
-      // Fallback to form submission
-      const form = document.querySelector('#FacetFiltersForm');
-      if (form) {
-        form.submit();
-      }
+      // Collection page - go to base collection URL
+      window.location.href = '{{ results_url | split: '?' | first }}';
     }
   };
 
   // Clear all filters function for mobile
   window.clearAllFiltersMobile = function () {
-    // Uncheck all filter checkboxes in mobile form
-    document.querySelectorAll('#FacetFiltersFormMobile input[type="checkbox"][name^="filter."]').forEach((input) => {
-      input.checked = false;
-    });
-
-    // Clear all price range inputs in mobile form
-    document.querySelectorAll('#FacetFiltersFormMobile input[type="number"]').forEach((input) => {
-      input.value = '';
-    });
-
-    // Reset sort to default
-    const sortInputs = document.querySelectorAll('input[name="sort_by"]');
-    sortInputs.forEach((input) => {
-      input.checked = false;
-    });
-
-    // Hide the mobile tags container immediately
-    const tagsContainer = document.querySelector('.active-filters-tags-container-mobile');
-    if (tagsContainer) {
-      tagsContainer.style.display = 'none';
-    }
-
-    // Apply the filter changes
-    if (typeof window.applyFiltersAjax === 'function') {
-      window.applyFiltersAjax();
+    // For search pages, preserve the search query
+    const searchInput = document.querySelector('input[name="q"]');
+    const searchQuery = searchInput ? searchInput.value : '';
+    
+    // Navigate to base URL with search query but no filters
+    if (searchQuery) {
+      // Search page - keep the search term but clear filters
+      window.location.href = '{{ routes.search_url }}?q=' + encodeURIComponent(searchQuery) + '&options%5Bprefix%5D=last';
     } else {
-      // Fallback to form submission
-      const form = document.querySelector('#FacetFiltersFormMobile');
-      if (form) {
-        form.submit();
-      }
+      // Collection page - go to base collection URL
+      window.location.href = '{{ results_url | split: '?' | first }}';
     }
   };
 

--- a/templates/search.json
+++ b/templates/search.json
@@ -14,9 +14,19 @@
         "article_show_author": false,
         "columns_mobile": "2"
       }
+    },
+    "scrolling-marquee": {
+      "type": "scrolling-marquee",
+      "settings": {
+        "marquee_text": "SHOWCASE PROMOTIONS OR SPECIAL OFFERS",
+        "scroll_speed": 230,
+        "pause_on_hover": false,
+        "color_scheme": "scheme-1"
+      }
     }
   },
   "order": [
-    "main"
+    "main",
+    "scrolling-marquee"
   ]
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Revamps the search results layout with horizontal filters, configurable columns/spacing, and AJAX-friendly facets; adds desktop column control to collection grids, tweaks input label positioning, and inserts a marquee section on the search template.
> 
> - **Search page (sections/main-search.liquid)**
>   - Switch to horizontal filters UI; remove vertical sort block; add padding/spacing synced to global settings.
>   - New configurable layout: `products_per_page`, `columns_desktop`, `columns_mobile`; desktop grid uses `grid-template-columns` via setting.
>   - Product grid rewritten to animated div-based layout; updated pagination wrapper; added empty-state message pre-search.
>   - Includes `scroll-animations.css/js` and `main-collection-product-grid.css`; expose filters drawer speed and filter icon customization settings.
> - **Facets (snippets/facets.liquid)**
>   - Header shows "Search Results" and count when searching.
>   - `clearAllFilters` (desktop/mobile) preserves `q` and routes appropriately for search vs. collection.
> - **Collection grid (sections/main-collection-product-grid.liquid)**
>   - Add desktop `grid-template-columns` driven by `section.settings.columns_desktop`.
> - **Styles (assets/base.css)**
>   - Adjust floating label position: `.field__label` top from `+0.5rem` to `+0rem` when input is active.
> - **Template (templates/search.json)**
>   - Add `scrolling-marquee` section to the search page order.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d0bc1b52e7e5a76dee650cf4d8819405446a7d8f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->