### PR TITLE
sticky cart sidebar

### DIFF
--- a/assets/main-cart-items.css
+++ b/assets/main-cart-items.css
@@ -131,7 +131,11 @@
     align-items: center;
     margin-bottom: var(--space-2xl);
     padding-bottom: var(--space-lg);
+    padding-top: var(--space-lg);
     border-bottom: 1px solid var(--border);
+ 
+    background-color: var(--background);
+    z-index: 1;
 }
 
 .cart-title {
@@ -150,9 +154,9 @@
 .cart-content {
     display: flex;
     gap: var(--space-5xl);
-    align-items: stretch;
+    align-items: flex-start;
     flex: 1;
-    overflow: hidden;
+    overflow: visible;
 }
 
 .cart-items {
@@ -420,6 +424,8 @@
 
 .cart-sidebar {
     flex: 1;
+    position: sticky;
+    top: 120px;
     min-width: 300px;
     display: flex;
     flex-direction: column;
@@ -985,6 +991,7 @@ details:not([open]) .pmorph__icon::after {
     }
     .cart-head1 {
         margin-bottom: 0;
+        position:unset;
     }
 
     .empty-cart-message {
@@ -992,14 +999,12 @@ details:not([open]) .pmorph__icon::after {
         padding: var(--space-2xl) 0;
     }
     
-    .cart-container {
-        padding-inline: var(--gutter-md);
-    }
+  
 }
 
 @media (min-width: 990px) {
     .cart-container {
-        padding-inline: var(--gutter-sm);
+        padding-inline: var(--sections-side-space);
     }
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Makes the cart sidebar sticky and tweaks header, layout alignment, overflow, and large-screen padding.
> 
> - **Cart layout and behavior**:
>   - `assets/main-cart-items.css`:
>     - Make `
> .cart-sidebar` sticky with `top: 120px`.
>     - Adjust `
> .cart-content` to `align-items: flex-start` and `overflow: visible`.
>     - Update `
> .cart-head1` with `padding-top`, `background-color`, and `z-index`; unset `position` on mobile.
>     - Large screens: set `
> .cart-container` `padding-inline` to `--sections-side-space`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f6b71880c5d586023298565676aa5a1758ba9b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->