### PR TITLE
related product spacing issues

### DIFF
--- a/assets/section-related-products.css
+++ b/assets/section-related-products.css
@@ -73,7 +73,7 @@
   font-size: 3.5rem;
   left: -3px;
   font-weight: 500;
-  margin: 0px 10px 50px;
+  margin: 0px 10px 20px;
 }
 
 @media (min-width: 500px) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Reduces top padding and bottom margin for the `related-products-main-heading` to correct spacing across breakpoints.
> 
> - **CSS (Related Products)**:
>   - **Heading spacing**:
>     - Remove `padding-top` from ` .related-products-main-heading` (base, ≤480px, ≥768px).
>     - Reduce bottom margin from `50px` to `20px` on ` .related-products-main-heading`.
>   - **Mobile/Tablet**:
>     - Keep `padding-bottom` while removing top padding to tighten vertical spacing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 80e101b04900bb4a660f2d0875c5532730f601bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->