### PR TITLE
hover animations

### DIFF
--- a/sections/content-block.liquid
+++ b/sections/content-block.liquid
@@ -272,7 +272,10 @@
     align-items: center;
     width: 100%;
     padding-bottom: 0;
-    transition: color 0.15s ease-in-out;
+  }
+
+  section.cb-container-image-and-text .cb-accordion-header.active h3 {
+    color: var(--accent);
   }
 
   section.cb-container-image-and-text .cb-accordion-header h3 {
@@ -285,6 +288,26 @@
     color: rgb(var(--text));
     padding-bottom: 0;
     line-height: 1;
+  }
+
+  /* Hover animations - desktop only */
+  @media (min-width: 768px) {
+    section.cb-container-image-and-text .cb-accordion-header {
+      transition: all 0.3s ease;
+    }
+
+    section.cb-container-image-and-text .cb-accordion-header:hover {
+      transform: scale(1.005);
+    }
+
+    section.cb-container-image-and-text .cb-accordion-header h3 {
+      transition: color 0.3s ease;
+    }
+
+    section.cb-container-image-and-text .cb-accordion-header:hover h3 {
+      color: var(--accent);
+      transform: scale(1.005);
+    }
   }
 
   section.cb-container-image-and-text .cb-svg-arrow-down {
@@ -329,24 +352,28 @@
     padding-top: 0;
   }
 
-  section.cb-container-image-and-text .cb-accordion-header:hover {
-    color: var(--sale_badge);
-  }
-
-  section.cb-container-image-and-text .cb-accordion-header.active {
-    color: var(--sale_badge);
-  }
-
-  section.cb-container_image_and_text .cb-accordion-header.active h3 {
-    color: var(--sale_badge);
-  }
-
   section.cb-container-image-and-text .cb-accordion-header .cb-plus-minus-icon {
     width: 20px;
     height: 20px;
     flex-shrink: 0;
-    transition: all 0.3s ease;
-    stroke: rgb(var(--text));
+    color: rgb(var(--text));
+    transform-origin: center;
+  }
+
+  section.cb-container-image-and-text .cb-accordion-header.active .cb-plus-minus-icon {
+    color: var(--accent);
+  }
+
+  /* Icon hover animations - desktop only */
+  @media (min-width: 768px) {
+    section.cb-container-image-and-text .cb-accordion-header .cb-plus-minus-icon {
+      transition: all 0.3s ease;
+    }
+
+    section.cb-container-image-and-text .cb-accordion-header:hover .cb-plus-minus-icon {
+      color: var(--accent);
+      transform: scale(1.35);
+    }
   }
 
   section.cb-container-image-and-text .cb-accordion-header .cb-vertical-line {
@@ -357,13 +384,6 @@
     opacity: 0;
   }
 
-  section.cb-container-image-and-text .cb-accordion-header.active .cb-plus-minus-icon {
-    stroke: var(--sale_badge);
-  }
-
-  section.cb-container-image-and-text .cb-accordion-header:hover .cb-plus-minus-icon {
-    stroke: var(--sale_badge);
-  }
 
   section.cb-container-image-and-text .cb-accordion-header .cb-arrow-img {
     position: relative;

--- a/sections/faq.liquid
+++ b/sections/faq.liquid
@@ -13,12 +13,39 @@
 {% endif %}
 
 <style>
+  .ans {
+    transform-origin: left;
+  }
+
   .plus-minus-icon {
     width: 20px;
     height: 24px;
     margin-right: 10px;
     flex-shrink: 0;
-    transition: all 0.6s ease;
+    transform-origin: center;
+    color: currentColor;
+  }
+
+  /* Hover animations - desktop only */
+  @media (min-width: 768px) {
+    .ans {
+      transition: all 0.3s ease;
+    }
+
+    .faq-row:hover .ans {
+      color: var(--accent);
+      transform: scale(1.02);
+    }
+
+    .plus-minus-icon {
+      transition: all 0.3s ease;
+    }
+
+    .faq-row:hover .plus-minus-icon {
+      transform: scale(1.35);
+      cursor: pointer;
+      color: var(--accent);
+    }
   }
 
   .plus-minus-icon .vertical-line {

--- a/sections/tech-specs.liquid
+++ b/sections/tech-specs.liquid
@@ -530,23 +530,25 @@
        min-height: 83px;
      }
 
-     /* Icon hover effects */
-     .functionality-icons-background {
-       transition: all 0.3s ease;
-       cursor: pointer;
-     }
+     /* Icon hover effects - desktop only */
+     @media (min-width: 768px) {
+       .functionality-icons-background {
+         transition: all 0.3s ease;
+         cursor: pointer;
+       }
 
-     .functionality-icons-background:hover {
-       transform: scale(1.05);
-       box-shadow: 0 6px 20px rgba(0, 0, 0, 0.15) !important;
-     }
+       .functionality-icons-background:hover {
+         transform: scale(1.05);
+         box-shadow: 0 6px 20px rgba(0, 0, 0, 0.15) !important;
+       }
 
-     .functionality-icons-background:hover .feature-icon {
-       filter: brightness(0) saturate(100%) invert(27%) sepia(51%) saturate(2878%) hue-rotate(346deg) brightness(104%) contrast(97%);
-     }
+       .functionality-icons-background:hover .feature-icon {
+         filter: brightness(0) saturate(100%) invert(27%) sepia(51%) saturate(2878%) hue-rotate(346deg) brightness(104%) contrast(97%);
+       }
 
-     .functionality-icons-background:hover svg {
-       color: {{ section.settings.icon_hover_color | default: '#ff6b35' }};
+       .functionality-icons-background:hover svg {
+         color: {{ section.settings.icon_hover_color | default: '#ff6b35' }};
+       }
      }
      @media (max-width: 1024px){
       .tech-left-box {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds desktop-only hover/scale and accent color animations to content block accordions, FAQ rows/icons, and tech specs feature icons, with refined active states.
> 
> - **Sections/content-block.liquid**
>   - Add desktop-only hover animations (scale, color) for `.cb-accordion-header` and `h3`.
>   - Introduce `.cb-plus-minus-icon` styling; change active/hover to use `color: var(--accent)` and scale on hover.
>   - Remove prior generic hover color rules and stroke-based styles.
> - **Sections/faq.liquid**
>   - Add desktop-only hover animations for `.faq-row` affecting `.ans` text and `.plus-minus-icon` (scale, accent color).
>   - Set transform origins; shift to `currentColor` for icon coloring.
> - **Sections/tech-specs.liquid**
>   - Scope functionality icon hover effects to desktop via media query; maintain scale/box-shadow and icon color/filter on hover.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bdf4f5e282021e2c567778dec348c2550aae26cb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->