### PR TITLE
video-with-text section

### DIFF
--- a/sections/video-with-text.liquid
+++ b/sections/video-with-text.liquid
@@ -629,9 +629,25 @@
 
     {%- comment -%} DESKTOP VIDEO - shown on screens > 750px {%- endcomment -%}
     {% if section.settings.video_source == 'external' and section.settings.video_url != blank %}
+      {%- comment -%} POSTER IMAGE - sits behind video, shows in preview {%- endcomment -%}
+      {% if section.settings.cover_image != blank %}
+        <div class="w-full h-full absolute inset-0" style="z-index: 0;">
+          {%- assign cover_width = 1920 -%}
+          {%- assign cover_height = cover_width | divided_by: section.settings.cover_image.aspect_ratio | round -%}
+          <img
+            src="{{ section.settings.cover_image | image_url: width: 1920 }}"
+            alt="{{ section.settings.cover_image.alt | escape }}"
+            width="{{ cover_width }}"
+            height="{{ cover_height }}"
+            class="w-full h-full object-cover"
+            loading="eager"
+          >
+        </div>
+      {% endif %}
+      
       <div
         class="video-with-text-iframe {% if has_mobile_video %}video-desktop-only{% endif %}"
-        style="position:relative;"
+        style="position:relative; z-index: 1;"
       >
         {% if section.settings.video_url.type == 'youtube' %}
           <iframe
@@ -698,9 +714,25 @@
         </button>
       </div>
     {% elsif section.settings.video_source == 'shopify' and section.settings.shopify_video != blank %}
+      {%- comment -%} POSTER IMAGE - sits behind video, shows in preview {%- endcomment -%}
+      {% if section.settings.cover_image != blank %}
+        <div class="w-full h-full absolute inset-0" style="z-index: 0;">
+          {%- assign cover_width = 1920 -%}
+          {%- assign cover_height = cover_width | divided_by: section.settings.cover_image.aspect_ratio | round -%}
+          <img
+            src="{{ section.settings.cover_image | image_url: width: 1920 }}"
+            alt="{{ section.settings.cover_image.alt | escape }}"
+            width="{{ cover_width }}"
+            height="{{ cover_height }}"
+            class="w-full h-full object-cover"
+            loading="eager"
+          >
+        </div>
+      {% endif %}
+      
       <div
         class="video-with-text-iframe {% if has_mobile_video %}video-desktop-only{% endif %}"
-        style="position:relative;"
+        style="position:relative; z-index: 1;"
       >
         {{
           section.settings.shopify_video
@@ -875,15 +907,28 @@
       {% endif %}
     {% endif %}
 
-    {%- comment -%} FALLBACK: No video selected {%- endcomment -%}
+    {%- comment -%} FALLBACK: Show placeholder when no video OR when default video with no cover image {%- endcomment -%}
     {% assign has_desktop_video = false %}
+    {% assign is_default_video = false %}
+    
     {% if section.settings.video_source == 'external' and section.settings.video_url != blank %}
       {% assign has_desktop_video = true %}
+      {% if section.settings.video_url.id == '_9VUPq3SxOc' %}
+        {% assign is_default_video = true %}
+      {% endif %}
     {% elsif section.settings.video_source == 'shopify' and section.settings.shopify_video != blank %}
       {% assign has_desktop_video = true %}
     {% endif %}
+    
+    {%- comment -%} Show placeholder if: no video, OR default video without cover image {%- endcomment -%}
+    {% assign show_placeholder = false %}
+    {% if has_desktop_video == false and has_mobile_video == false %}
+      {% assign show_placeholder = true %}
+    {% elsif is_default_video and section.settings.cover_image == blank %}
+      {% assign show_placeholder = true %}
+    {% endif %}
 
-    {% unless has_desktop_video or has_mobile_video %}
+    {% if show_placeholder %}
       <div
         class="flex bg-gray-400 items-center justify-center w-full h-full"
         role="img"
@@ -891,7 +936,7 @@
       >
         {{ 'lifestyle-2' | placeholder_svg_tag: 'w-auto h-auto opacity-30' }}
       </div>
-    {% endunless %}
+    {% endif %}
     {% if section.settings.enable_overlay_animation %}
       <div class="video-with-text-media-overlay-{{ section.id }}"></div>
     {% endif %}
@@ -1383,6 +1428,7 @@ document.addEventListener('DOMContentLoaded', function() {
       "id": "video_url",
       "label": "YouTube/Vimeo URL",
       "accept": ["youtube", "vimeo"],
+      "default": "https://www.youtube.com/watch?v=_9VUPq3SxOc",
       "info": "Video for desktop and tablet"
     },
     {
@@ -1390,6 +1436,12 @@ document.addEventListener('DOMContentLoaded', function() {
       "id": "shopify_video",
       "label": "Shopify Video",
       "info": "Video for desktop and tablet"
+    },
+    {
+      "type": "image_picker",
+      "id": "cover_image",
+      "label": "Cover image",
+      "info": "Fallback image shown in theme editor preview and for devices that block autoplay"
     },
     {
       "type": "checkbox",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds cover image (poster) support and refined placeholder logic to the video-with-text section, with layering tweaks and a default YouTube URL.
> 
> - **sections/video-with-text.liquid**:
>   - **Cover image support**: Adds `section.settings.cover_image` as a poster behind external/Shopify desktop videos with proper sizing and eager loading.
>   - **Layering**: Sets video container `z-index: 1` and poster at `z-index: 0` to ensure correct stacking.
>   - **Fallback logic**: Introduces `show_placeholder` to display placeholder when no video is set or when the default YouTube video is used without a cover; replaces previous simple check.
>   - **Schema**:
>     - Sets default `video_url` to `https://www.youtube.com/watch?v=_9VUPq3SxOc`.
>     - Adds new `image_picker` setting `cover_image` with help text.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bdc0d9349bf7fdd61fa51e7ba3ff46ff3b704460. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->