### PR TITLE
spacing issues in footer group

### DIFF
--- a/sections/footer-group.json
+++ b/sections/footer-group.json
@@ -56,6 +56,8 @@
         "show_store_name": true,
         "padding_top": 0,
         "padding_bottom": 0,
+        "margin_top": 0,
+        "margin_bottom": 0,
         "email_input_color": "#ffffff",
         "menu_item_color": "#ffffff",
         "hover_color": "#FFFFFF"

--- a/sections/footer.liquid
+++ b/sections/footer.liquid
@@ -59,7 +59,7 @@
 <footer
   class="bb-footer-container color-{{ section.settings.color_scheme }} relative overflow-hidden scroll-fade-trigger scroll-fade-up footer-container"
   style="
-    padding-top: var(--sections-spacing-top);
+    padding-top: {{ section.settings.padding_top }}px;
     padding-bottom: {{ section.settings.padding_bottom }}px;
     padding-left: {{ side_padding }}px;
     padding-right: {{ side_padding }}px;
@@ -571,6 +571,16 @@
     {
       "type": "header",
       "content": "Spacing"
+    },
+    {
+      "type": "range",
+      "id": "padding_top",
+      "min": 0,
+      "max": 100,
+      "step": 5,
+      "unit": "px",
+      "label": "Top Padding",
+      "default": 10
     },
     {
       "type": "range",

--- a/sections/localization-selector.liquid
+++ b/sections/localization-selector.liquid
@@ -82,10 +82,7 @@
   {% assign side_padding = 20 %}
 {% endif %}
 
-<section
-  class="color-{{ section.settings.color_scheme }}"
-  style="padding-top: var(--sections-spacing-top); padding-bottom: var(--sections-spacing-bottom);"
->
+<section class="color-{{ section.settings.color_scheme }} ">
   <!-- Footer Layout - Single Row -->
   <div
     class="footer-margin-class footer-bottom-section "
@@ -161,19 +158,19 @@
 </section>
 
 <style>
-  /* Section Container */
-  .shopify-section-localization {
-    width: 100%;
-    font-family: var(--font-body-family);
-    margin: 0 !important;
-    padding: 0 !important;
-    overflow: visible !important;
-  }
+    /* Section Container */
+    .shopify-section-localization {
+      width: 100%;
+      font-family: var(--font-body-family);
+      margin: 0 !important;
+      padding: 0 !important;
+      overflow: visible !important;
+    }
 
-  /* Footer Bottom Layout */
-  .footer-bottom-section {
-    min-height: var(--section-height, 40px);
-  }
+    /* Footer Bottom Layout */
+    .footer-bottom-section {
+      min-height: var(--section-height, 40px);
+    }
 
   .footer-single-row {
     display: grid;
@@ -187,160 +184,160 @@
     box-sizing: border-box;
   }
 
-  .footer-left,
-  .footer-center,
-  .footer-right {
-    overflow: visible !important;
-    min-height: 28px;
-    display: flex;
-    align-items: center;
-    color: var(--text);
-  }
+    .footer-left,
+    .footer-center,
+    .footer-right {
+      overflow: visible !important;
+      min-height: 28px;
+      display: flex;
+      align-items: center;
+      color: var(--text);
+    }
 
-  .footer-left {
-    justify-content: flex-start;
-  }
+    .footer-left {
+      justify-content: flex-start;
+    }
 
-  .footer-center {
-    justify-content: center;
-    text-align: center;
-    flex-grow: 1;
-  }
+    .footer-center {
+      justify-content: center;
+      text-align: center;
+      flex-grow: 1;
+    }
 
-  .footer-right {
-    justify-content: flex-end;
-  }
+    .footer-right {
+      justify-content: flex-end;
+    }
 
-  /* Localization Container */
-  .footer__localization {
-    display: flex;
-    align-items: center;
-    gap: 1rem;
-    flex-wrap: nowrap;
-    overflow: visible !important;
-    min-height: 28px;
-  }
+    /* Localization Container */
+    .footer__localization {
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+      flex-wrap: nowrap;
+      overflow: visible !important;
+      min-height: 28px;
+    }
 
-  /* Ensure all child elements align on the same baseline */
-  .footer__localization > * {
-    display: flex;
-    align-items: center;
-  }
+    /* Ensure all child elements align on the same baseline */
+    .footer__localization > * {
+      display: flex;
+      align-items: center;
+    }
 
-  .footer__country-selector,
-  .footer__language-selector {
-    display: flex;
-    align-items: center;
-  }
+    .footer__country-selector,
+    .footer__language-selector {
+      display: flex;
+      align-items: center;
+    }
 
-  .footer__country-selector .localization-form,
-  .footer__language-selector .localization-form {
-    display: flex;
-    align-items: center;
-    margin: 0;
-  }
+    .footer__country-selector .localization-form,
+    .footer__language-selector .localization-form {
+      display: flex;
+      align-items: center;
+      margin: 0;
+    }
 
-  .footer__country-selector .localization-selector,
-  .footer__language-selector .localization-selector {
-    display: flex;
-    align-items: center;
-  }
+    .footer__country-selector .localization-selector,
+    .footer__language-selector .localization-selector {
+      display: flex;
+      align-items: center;
+    }
 
-  /* Ensure disclosure divs align properly */
-  .footer__localization .disclosure,
-  .footer__localization .group {
-    display: flex;
-    align-items: center;
-  }
+    /* Ensure disclosure divs align properly */
+    .footer__localization .disclosure,
+    .footer__localization .group {
+      display: flex;
+      align-items: center;
+    }
 
-  /* Align buttons properly */
-  .footer__localization .disclosure__button,
-  .footer__localization .localization-form__select {
-    display: flex;
-    align-items: center;
-    padding: 0;
-    margin: 0;
-    min-height: auto;
-    height: auto;
-  }
+    /* Align buttons properly */
+    .footer__localization .disclosure__button,
+    .footer__localization .localization-form__select {
+      display: flex;
+      align-items: center;
+      padding: 0;
+      margin: 0;
+      min-height: auto;
+      height: auto;
+    }
 
-  /* Localization Form Styling */
-  .footer__country-selector,
-  .footer__language-selector {
-    font-family: var(--font-body-family);
-    font-weight: var(--font-body-weight);
-    position: relative;
-    overflow: visible !important;
-  }
+    /* Localization Form Styling */
+    .footer__country-selector,
+    .footer__language-selector {
+      font-family: var(--font-body-family);
+      font-weight: var(--font-body-weight);
+      position: relative;
+      overflow: visible !important;
+    }
 
-  .localization-form {
-    position: relative;
-    overflow: visible !important;
-  }
+    .localization-form {
+      position: relative;
+      overflow: visible !important;
+    }
 
-  .localization-selector {
-    position: relative;
-    overflow: visible !important;
-    z-index: 10;
-  }
+    .localization-selector {
+      position: relative;
+      overflow: visible !important;
+      z-index: 10;
+    }
 
-  /* Ensure dropdowns are properly positioned */
-  .localization-form .localization-selector select,
-  .localization-form .localization-selector .disclosure {
-    position: relative;
-    overflow: visible !important;
-  }
+    /* Ensure dropdowns are properly positioned */
+    .localization-form .localization-selector select,
+    .localization-form .localization-selector .disclosure {
+      position: relative;
+      overflow: visible !important;
+    }
 
-  /* Copyright Section */
-  .footer__copyright {
-    width: 100%;
-    max-width: 100%;
-    padding: var(--space-mini) 0;
-  }
+    /* Copyright Section */
+    .footer__copyright {
+      width: 100%;
+      max-width: 100%;
+      padding: var(--space-mini) 0;
+    }
 
-  .copyright-line {
-    display: inline-block;
-    white-space: nowrap;
-    line-height: 1.4;
-  }
+    .copyright-line {
+      display: inline-block;
+      white-space: nowrap;
+      line-height: 1.4;
+    }
 
-  .policies-inline {
-    display: inline;
-  }
+    .policies-inline {
+      display: inline;
+    }
 
-  .policies-inline a {
-    color: rgba(var(--color-foreground));
-    text-decoration: none;
-  }
+    .policies-inline a {
+      color: rgba(var(--color-foreground));
+      text-decoration: none;
+    }
 
-  .policies-inline a:hover {
-    text-decoration: underline;
-  }
+    .policies-inline a:hover {
+      text-decoration: underline;
+    }
 
-  .policy-separator {
-    color: rgba(var(--color-foreground));
-    margin: 0 0.5rem;
-  }
+    .policy-separator {
+      color: rgba(var(--color-foreground));
+      margin: 0 0.5rem;
+    }
 
-  /* Payment Icons */
-  .payments-icons {
-    padding: var(--space-mini) 0;
-  }
+    /* Payment Icons */
+    .payments-icons {
+      padding: var(--space-mini) 0;
+    }
 
-  .payments-icons .footer__payment {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.5rem;
-    align-items: center;
-    list-style: none;
-    margin: 0;
-    padding: 0;
-  }
+    .payments-icons .footer__payment {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+      align-items: center;
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }
 
-  .payments-icons .payment-icon {
-    height: 20px;
-    width: auto;
-  }
+    .payments-icons .payment-icon {
+      height: 20px;
+      width: auto;
+    }
 
   /* Mobile Responsive */
   @media (max-width: 749px) {
@@ -354,48 +351,48 @@
       min-height: calc(var(--section-height, 40px) + 20px);
     }
 
-    .policies-inline {
-      display: none;
-    }
-    .footer-left {
-      justify-content: center;
-      width: 100%;
-      order: 1;
-      overflow: visible !important;
-    }
+      .policies-inline {
+        display: none;
+      }
+      .footer-left {
+        justify-content: center;
+        width: 100%;
+        order: 1;
+        overflow: visible !important;
+      }
 
-    .footer-center {
-      order: 1;
-      width: 100%;
-    }
+      .footer-center {
+        order: 1;
+        width: 100%;
+      }
 
-    .footer-right {
-      justify-content: center;
-      width: 100%;
-      order: 3;
-    }
+      .footer-right {
+        justify-content: center;
+        width: 100%;
+        order: 3;
+      }
 
-    .footer__localization {
-      justify-content: center;
-      flex-direction: row;
-      align-items: center;
-      gap: 1rem;
-      flex-wrap: wrap;
-      overflow: visible !important;
-    }
+      .footer__localization {
+        justify-content: center;
+        flex-direction: row;
+        align-items: center;
+        gap: 1rem;
+        flex-wrap: wrap;
+        overflow: visible !important;
+      }
 
-    .copyright-line {
-      white-space: normal;
-      text-align: center;
-      line-height: 1.4;
-    }
+      .copyright-line {
+        white-space: normal;
+        text-align: center;
+        line-height: 1.4;
+      }
 
-    .footer__localization,
-    .footer__country-selector,
-    .footer__language-selector {
-      z-index: 1;
+      .footer__localization,
+      .footer__country-selector,
+      .footer__language-selector {
+        z-index: 1;
+      }
     }
-  }
 
   /* Tablet */
   @media (min-width: 750px) and (max-width: 989px) {
@@ -412,121 +409,121 @@
     }
   }
 
-  /* Desktop */
-  @media (min-width: 990px) {
+    /* Desktop */
+    @media (min-width: 990px) {
+      .footer__localization {
+        gap: 1.5rem;
+        overflow: visible !important;
+      }
+
+      .footer-single-row {
+        gap: 2rem;
+        overflow: visible !important;
+      }
+    }
+
+    /* Isolate stacking context */
+    .isolate {
+      isolation: isolate;
+    }
+
+    /* Utility classes */
+    .caption-large {
+      font-size: var(--t-b-3-size);
+      line-height: calc(1 + 0.5 / var(--font-body-scale));
+      letter-spacing: 0.04rem;
+    }
+
+    .text-body {
+      color: rgb(var(--color-foreground));
+      font-style: var(--font-body-style);
+      font-weight: var(--font-body-weight);
+    }
+
+    .caption {
+      font-size: var(--tm-b-4-size);
+      line-height: calc(1 + 0.8 / var(--font-body-scale));
+      letter-spacing: 0.04rem;
+    }
+
+    /* Ensure proper z-index for dropdowns */
+    localization-form {
+      position: relative;
+      z-index: 10;
+    }
+
+    /* Additional styling for better UX */
+    .footer__localization localization-form + localization-form {
+      margin-left: 0;
+    }
+
+    /* Fix any potential overflow issues */
+    .footer-bottom-section,
+    .footer-bottom-section * {
+      box-sizing: border-box;
+    }
+
+    /* Ensure body doesn't get extra scroll when dropdown is open */
+    body.localization-form-open {
+      overflow-x: hidden;
+    }
+
+    /* Fix z-index to appear above product-difference slider and other sections */
+    .footer__localization,
+    .footer__country-selector,
+    .footer__language-selector {
+      position: relative;
+    }
+
+    /* Ensure dropdowns have even higher z-index */
+    .disclosure__list-wrapper,
+    .bb-disclosure__list-wrapper {
+      position: absolute;
+      z-index: 10001 !important;
+    }
+
+    .bb-ls-disclosure__list-wrapper {
+      bottom: 120%;
+      display: block;
+      overflow: visible !important;
+      background: var(--header_background);
+      max-height: none !important;
+    }
+    /* Make sure parent containers don't clip dropdowns */
+    .shopify-section-localization,
+    .footer-bottom-section,
+    .footer-single-row,
+    .footer-left,
     .footer__localization {
-      gap: 1.5rem;
       overflow: visible !important;
     }
 
-    .footer-single-row {
-      gap: 2rem;
+    /* Override any parent overflow issues */
+    .bb-footer-container,
+    .footer-container {
       overflow: visible !important;
     }
-  }
 
-  /* Isolate stacking context */
-  .isolate {
-    isolation: isolate;
-  }
+    /* Language selector overlay (matching currency selector) */
+    .language-selector__overlay {
+      display: none;
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background: rgba(0, 0, 0, 0.3);
+      z-index: 9998;
+    }
 
-  /* Utility classes */
-  .caption-large {
-    font-size: var(--t-b-3-size);
-    line-height: calc(1 + 0.5 / var(--font-body-scale));
-    letter-spacing: 0.04rem;
-  }
+    /* Language selector dropdown styling to match currency selector */
+    .language-selector__list {
+      background: var(--header_background);
+    }
 
-  .text-body {
-    color: rgb(var(--color-foreground));
-    font-style: var(--font-body-style);
-    font-weight: var(--font-body-weight);
-  }
-
-  .caption {
-    font-size: var(--tm-b-4-size);
-    line-height: calc(1 + 0.8 / var(--font-body-scale));
-    letter-spacing: 0.04rem;
-  }
-
-  /* Ensure proper z-index for dropdowns */
-  localization-form {
-    position: relative;
-    z-index: 10;
-  }
-
-  /* Additional styling for better UX */
-  .footer__localization localization-form + localization-form {
-    margin-left: 0;
-  }
-
-  /* Fix any potential overflow issues */
-  .footer-bottom-section,
-  .footer-bottom-section * {
-    box-sizing: border-box;
-  }
-
-  /* Ensure body doesn't get extra scroll when dropdown is open */
-  body.localization-form-open {
-    overflow-x: hidden;
-  }
-
-  /* Fix z-index to appear above product-difference slider and other sections */
-  .footer__localization,
-  .footer__country-selector,
-  .footer__language-selector {
-    position: relative;
-  }
-
-  /* Ensure dropdowns have even higher z-index */
-  .disclosure__list-wrapper,
-  .bb-disclosure__list-wrapper {
-    position: absolute;
-    z-index: 10001 !important;
-  }
-
-  .bb-ls-disclosure__list-wrapper {
-    bottom: 120%;
-    display: block;
-    overflow: visible !important;
-    background: var(--header_background);
-    max-height: none !important;
-  }
-  /* Make sure parent containers don't clip dropdowns */
-  .shopify-section-localization,
-  .footer-bottom-section,
-  .footer-single-row,
-  .footer-left,
-  .footer__localization {
-    overflow: visible !important;
-  }
-
-  /* Override any parent overflow issues */
-  .bb-footer-container,
-  .footer-container {
-    overflow: visible !important;
-  }
-
-  /* Language selector overlay (matching currency selector) */
-  .language-selector__overlay {
-    display: none;
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background: rgba(0, 0, 0, 0.3);
-    z-index: 9998;
-  }
-
-  /* Language selector dropdown styling to match currency selector */
-  .language-selector__list {
-    background: var(--header_background);
-  }
-
-  .language-selector .disclosure__list {
-    background: var(--header_background);
-  }
+    .language-selector .disclosure__list {
+      background: var(--header_background);
+    }
 </style>
 
 <script>

--- a/sections/sub-footer.liquid
+++ b/sections/sub-footer.liquid
@@ -78,92 +78,98 @@
 
 {{ 'sub-footer.css' | asset_url | stylesheet_tag }}
 <style>
-  .site-credit-link:hover {
-    opacity: 1;
-    color: var(--accent);
-  }
-
-  .site-credit-link .default-text {
-    display: inline;
-  }
-
-  .site-credit-link .hover-text {
-    display: none;
-  }
-
-  .site-credit-link:hover .default-text {
-    display: none;
-  }
-
-  .site-credit-link:hover .hover-text {
-    display: inline;
-  }
-
-  @media screen and (max-width: 480px) {
-    .footer-container {
-      flex-direction: column;
-      gap: 1px;
+    .footer-text,
+    .site-credit-link {
+      color: var(--text);
     }
 
-    .footer-links {
-      flex-direction: column;
-      gap: 5px;
-      width: 100%;
-      order: 2;
-    }
-
-    .site-credit {
-      order: 1;
-      margin-bottom: 1rem;
-    }
-
-    .footer-text {
-      font-size: var(--tm-b-4-size);
-      line-height: 11px;
+    .site-credit-link:hover {
+      opacity: 1;
+      color: var(--accent);
     }
 
     .site-credit-link .default-text {
-      font-size: var(--tm-b-4-size);
-      line-height: 11px;
-      margin-left: 20px;
+      display: inline;
     }
 
     .site-credit-link .hover-text {
-      margin-left: 8px;
-      font-size: var(--tm-b-4-size);
-      line-height: 11px;
+      display: none;
     }
-  }
 
-  @media screen and (max-width: 480px) {
-    .site-credit {
-      margin-left: 70%;
+    .site-credit-link:hover .default-text {
+      display: none;
     }
-    .footer-links {
-      margin-top: -25px;
-    }
-    .footer-container {
-      margin-top: -3px;
-    }
-  }
 
-  /* Add margin-left for large screens only */
-  @media screen and (min-width: 1024px) {
-    .footer-links {
-      margin-left: 20px;
+    .site-credit-link:hover .hover-text {
+      display: inline;
     }
-  }
+
+    @media screen and (max-width: 480px) {
+      .footer-container {
+        flex-direction: column;
+        gap: 1px;
+      }
+
+      .footer-links {
+        flex-direction: column;
+        gap: 5px;
+        width: 100%;
+        order: 2;
+      }
+
+      .site-credit {
+        order: 1;
+        margin-bottom: 1rem;
+      }
+
+      .footer-text {
+        font-size: var(--tm-b-4-size);
+        line-height: 11px;
+      }
+
+      .site-credit-link .default-text {
+        font-size: var(--tm-b-4-size);
+        line-height: 11px;
+        margin-left: 20px;
+      }
+
+      .site-credit-link .hover-text {
+        margin-left: 8px;
+        font-size: var(--tm-b-4-size);
+        line-height: 11px;
+      }
+    }
+
+    @media screen and (max-width: 480px) {
+      .site-credit {
+        margin-left: 70%;
+      }
+      .footer-links {
+        margin-top: -25px;
+      }
+      .footer-container {
+        margin-top: -3px;
+      }
+    }
+
+    /* Add margin-left for large screens only */
+    @media screen and (min-width: 1024px) {
+      .footer-links {
+        margin-left: 20px;
+      }
+    }
 
   .custom-footer-style {
-    padding-top: var(--sections-spacing-top);
-    padding-bottom: var(--sections-spacing-bottom);
+    padding-top: var(--space-3xl);
+    padding-bottom: var(--space-3xl);
     padding-left: {{ side_padding }}px;
     padding-right: {{ side_padding }}px;
     line-height: normal;
+    background-color: var(--background);
   }
 </style>
 
-<div class="w-full flex justify-between items-center footer-container color-{{ section.settings.color_scheme }} custom-footer-style">
+<div class="w-full flex justify-between items-center color-{{ section.settings.color_scheme }} footer-container custom-footer-style">
   <div class="flex gap-8 footer-links">
     {% if section.settings.link1_text != blank %}
       <a


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds footer padding/margin controls, removes default section spacing from the localization selector, and refactors sub-footer styles to standardize spacing and colors.
> 
> - **Footer** (`sections/footer.liquid`, `sections/footer-group.json`):
>   - Use `section.settings.padding_top` and `padding_bottom` directly in inline styles; add `margin_top`/`margin_bottom` usage.
>   - Schema: add `range` setting for `padding_top`; JSON: add `margin_top` and `margin_bottom` defaults in `footer-group.json`.
> - **Localization Selector** (`sections/localization-selector.liquid`):
>   - Remove inline top/bottom padding (no `--sections-spacing-*`), keeping only color scheme class.
>   - Style block reflowed without functional changes to layout/JS.
> - **Sub-Footer** (`sections/sub-footer.liquid`):
>   - Standardize styles: set text colors, add background color, and switch padding to design tokens (`--space-3xl`).
>   - Consolidate responsive rules and minor class order cleanup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f2a2848a56769c6100b00b26a486a70fe94b76d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->