### PR TITLE
header issues fixed

### DIFF
--- a/assets/header.css
+++ b/assets/header.css
@@ -286,7 +286,7 @@
 
 .mega-menu-dropdown {
     position: absolute;
-    top: 85%;
+    top: 100%;
     left: 0;
     right: 0;
     z-index: var(--z-mobile-menu);
@@ -535,17 +535,39 @@
     width: 40%;
 }
 
+/* Ensure mega menu images don't overflow */
+.mega-menu-images > div {
+    max-height: 250px;
+    width: 100%;
+    max-width: 300px;
+}
+
+.mega-menu-images .aspect-\[4\/3\] {
+    max-height: 200px;
+    width: 100%;
+    height: auto;
+}
+
+.mega-menu-images img {
+    max-height: 200px;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
 /* Fixed height for mega menu when opened */
 .mega-menu-dropdown.open {
     min-height: 300px !important;
-    max-height: 300px !important;
-    height: 300px !important;
+    max-height: 450px !important;
+    height: auto !important;
 }
 
 /* Position scrolling text at bottom of mega menu */
 .mega-menu-dropdown .bb-mega-menu-first {
     position: relative;
-    height: 100%;
+    min-height: 300px;
+    max-height: 420px;
+    overflow: visible;
 }
 
 .mega-menu-dropdown .mega-menu-images {

--- a/snippets/facets.liquid
+++ b/snippets/facets.liquid
@@ -394,7 +394,7 @@
                   data-facet-summary="sort"
                 >
                   <div class="flex items-center">
-                    <h1 class="uppercase !text-[16px] w-[75px] !font-[500] facets-text-color">Sort By</h1>
+                    <h1 class="uppercase !text-[16px]  !font-[500] facets-text-color">Sort By</h1>
                     {% if facet_custom_icon_collapsed %}
                       <span class="custom-facet-icon" aria-hidden="true" data-icon-type="custom">
                         <img


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refines mega menu placement and sizing (with image overflow limits) and removes a fixed width from the facets Sort By heading.
> 
> - **Header/CSS**:
>   - **Mega menu**: Set `top: 100%` for `.mega-menu-dropdown`; increase open max height to `450px` and use `height: auto`; adjust `.bb-mega-menu-first` to min/max heights with visible overflow.
>   - **Images**: Add size constraints to `.mega-menu-images` children, `[4/3]` aspect blocks, and `img` to prevent overflow.
> - **Facets (snippets/facets.liquid)**:
>   - Remove fixed width class from `"Sort By"` heading.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b406e4b4455c2e87d26bb970d8eb72c795fc6b91. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->