### PR TITLE
side spacing

### DIFF
--- a/assets/section-related-products.css
+++ b/assets/section-related-products.css
@@ -79,6 +79,7 @@
 @media (min-width: 500px) {
   .related-products-main-heading {
     font-size: 5rem;
+    margin: 0px 0px 20px;
   }
 }
 
@@ -86,10 +87,11 @@
   .related-products-main-heading {
     font-size: var(--tm-h-4-size, 24px) !important;
     padding-bottom: var(--space-lg, 24px) !important;
+    margin: 0px 0px 20px
   }
 
   #related-products-heading {
-    margin: 0 7.5px 20px !important;
+    margin: 0 0 20px !important;
   }
 }
 
@@ -97,6 +99,7 @@
   .related-products-main-heading {
     font-size: 40px;
     padding-bottom: var(--space-4xl, 64px);
+    margin: 0px 10px 20px
   }
 
   .related-products-container {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Tightens and standardizes heading margins in related products to remove side spacing on small screens and align spacing across breakpoints.
> 
> - **CSS (related products)**:
>   - Standardize `margin` for `	.related-products-main-heading` across breakpoints:
>     - `@media (min-width: 500px)`: `margin: 0 0 20px`.
>     - `@media (max-width: 480px)`: `margin: 0 0 20px`.
>     - `@media (min-width: 768px)`: `margin: 0 10px 20px`.
>   - Adjust `#related-products-heading` on small screens (`@media (max-width: 480px)`) from `0 7.5px 20px` to `0 0 20px`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f95037ac6fec1655c8338473478cd44fe78dcb7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->