### PR TITLE
cart drawer

### DIFF
--- a/assets/cart-drawer-custom.js
+++ b/assets/cart-drawer-custom.js
@@ -353,26 +353,31 @@ function initializeCartDrawer() {
   // CART DRAWER CLOSE BUTTONS (CSP-compliant event listeners)
   // ===================================================================
 
-  // Add event listeners for close buttons
-  const closeButtons = document.querySelectorAll('.drawer__close, .drawer__close2');
-  closeButtons.forEach(function (button) {
-    button.addEventListener('click', function () {
-      const cartDrawer = this.closest('cart-drawer');
+  // Use event delegation for close buttons to handle dynamically refreshed content
+  document.addEventListener('click', function (e) {
+    // Check if the clicked element or its parent is a close button
+    const closeButton = e.target.closest('.drawer__close, .drawer__close2');
+    if (closeButton) {
+      e.preventDefault();
+      const cartDrawer = closeButton.closest('cart-drawer');
       if (cartDrawer && typeof cartDrawer.close === 'function') {
         cartDrawer.close();
       }
-    });
+    }
+  });
 
-    // Add keyboard accessibility
-    button.addEventListener('keydown', function (e) {
-      if (e.key === 'Enter' || e.key === ' ') {
+  // Add keyboard accessibility using event delegation
+  document.addEventListener('keydown', function (e) {
+    if (e.key === 'Enter' || e.key === ' ') {
+      const closeButton = e.target.closest('.drawer__close, .drawer__close2');
+      if (closeButton) {
         e.preventDefault();
-        const cartDrawer = this.closest('cart-drawer');
+        const cartDrawer = closeButton.closest('cart-drawer');
         if (cartDrawer && typeof cartDrawer.close === 'function') {
           cartDrawer.close();
         }
       }
-    });
+    }
   });
 
   // Add event listeners for size and color changes


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replace per-element close button listeners with document-level delegated click/keydown handlers to support dynamically refreshed cart drawer content and keyboard accessibility.
> 
> - **Cart Drawer (`assets/cart-drawer-custom.js`)**:
>   - **Event handling**: Switch close buttons (`.drawer__close`, `.drawer__close2`) to delegated `click` and `keydown` listeners on `document`.
>     - Preserves keyboard accessibility (Enter/Space).
>     - Works with dynamically refreshed cart drawer content.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b97ab2716cfe12356828334ebf0d9ef2b4bf58f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->