### PR TITLE
Add chevron hover animation to product difference slider

### DIFF
--- a/sections/product-difference.liquid
+++ b/sections/product-difference.liquid
@@ -722,15 +722,16 @@
         window.addEventListener('touchend', () => handle.classList.remove('dragging'));
 
         // Add hover animation for chevrons when slider handle area is hovered
-        // Listen on slider but only trigger when near center (handle position)
+        // Listen on slider and detect when near handle's actual position
         slider.addEventListener('mousemove', (e) => {
           const rect = slider.getBoundingClientRect();
-          const x = e.clientX - rect.left;
-          const centerX = rect.width / 2;
-          const distanceFromCenter = Math.abs(x - centerX);
+          const mouseX = e.clientX - rect.left;
+          const sliderValue = parseFloat(slider.value);
+          const handleX = (rect.width * sliderValue) / 100; // Handle's actual position based on slider value
+          const distanceFromHandle = Math.abs(mouseX - handleX);
           
-          // If within 100px of center (handle area), show hover effect
-          if (distanceFromCenter < 100 && handle) {
+          // If within 100px of handle's current position, show hover effect
+          if (distanceFromHandle < 100 && handle) {
             handle.classList.add('handle-hovered');
           } else if (handle) {
             handle.classList.remove('handle-hovered');


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a proximity-based hover animation for the slider handle chevrons, with CSS scaling and JS detection, plus pointer/hover area tweaks.
> 
> - **UI (sections/product-difference.liquid)**:
>   - **CSS**:
>     - Enable `pointer-events` and add padding on `#Handle-{{ section.id }}` to expand hover area.
>     - Add hover scaling for chevron SVG `path` via `.handle-hovered` with transitions.
>   - **JS**:
>     - Add `mousemove` proximity logic on the slider to toggle `handle-hovered` when cursor is within 100px of the handle; remove on `mouseleave`.
>     - Retain existing drag animation hooks (`.dragging`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d3974ffd927a31e30555d6a91c9bf8c7b3b23cf2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->