### PR TITLE
cursor bug

### DIFF
--- a/assets/header-currency.css
+++ b/assets/header-currency.css
@@ -39,6 +39,25 @@
     box-shadow: none;
 }
 
+/* Enable rotation for desktop dropdown arrows */
+.rotate-180 {
+    transform: rotate(180deg);
+}
+
+/* Mobile menu localization arrow - always face right, never rotate */
+.header-country-selector .mobile-country-arrow,
+.header-country-selector .bi-caret-right-fill {
+    transform: rotate(0deg) !important;
+    transition: none !important;
+}
+
+/* Override rotate-180 class for mobile menu - keep facing right */
+.header-country-selector .rotate-180,
+.header-country-selector .mobile-country-arrow.rotate-180,
+.header-country-selector .bi-caret-right-fill.rotate-180 {
+    transform: rotate(0deg) !important;
+    transition: none !important;
+}
 
 .bb-localization-form__select:hover.bb-localization-form__select:after
 {

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -1653,12 +1653,16 @@
     }
   });
 
+  // Desktop localization arrow rotation
   const button = document.querySelector('.bb-localization-form__select');
-  const arrow = button.querySelector('.dropdown-arrow');
-
-  button.addEventListener('click', () => {
-    arrow.classList.toggle('rotate-180');
-  });
+  if (button) {
+    const arrow = button.querySelector('.dropdown-arrow');
+    if (arrow) {
+      button.addEventListener('click', () => {
+        arrow.classList.toggle('rotate-180');
+      });
+    }
+  }
 
   // Recent Searches Functionality
   class RecentSearches {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Aligns arrow behavior: desktop dropdown arrow rotates while mobile localization arrows stay right-facing, with JS null-checks for safer binding.
> 
> - **Header localization arrows**:
>   - **CSS**: Add `rotate-180` utility for desktop dropdown arrows; override in `.header-country-selector` to keep mobile arrows right-facing and disable rotation/transitions.
>   - **JS (`sections/header.liquid`)**: Safeguard desktop arrow rotation handler with null checks before toggling `rotate-180` on `.dropdown-arrow`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c75bc17409afdeea01e389c21e57afa6e8382b2e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->