### PR TITLE
arrow hover and section specific padding

### DIFF
--- a/sections/collection-banner.liquid
+++ b/sections/collection-banner.liquid
@@ -1,14 +1,25 @@
 {% comment %}theme-check-disable ImgLazyLoading{% endcomment %}
 {{ 'collection-banner.css' | asset_url | stylesheet_tag }}
 
+<style>
+  .section-{{ section.id }}-padding {
+    padding-top: {{ section.settings.section_top_padding | default: 0 }}px;
+  }
+
+  @media (max-width: 749px) {
+    .section-{{ section.id }}-padding {
+      padding-top: {{ section.settings.section_top_padding_mobile | default: 0 }}px !important;
+    }
+  }
+</style>
+
 {% if section.settings.enabled %}
   <section
-    class="collection-banner-simple"
+    class="collection-banner-simple section-{{ section.id }}-padding"
     style="
       --banner-height: {{ section.settings.banner_height }}px;
       --banner-height-mobile: {{ section.settings.banner_height_mobile }}px;
       --side-space: {{ settings.side_space }}px;
-      --padding-top: var(--sections-spacing-top);
       --padding-bottom: var(--sections-spacing-bottom);
       --object-fit: {{ section.settings.object_fit }};
       --object-position: {{ section.settings.object_position }};
@@ -93,6 +104,32 @@
       "unit": "px",
       "label": "Banner height (Mobile)",
       "default": 500
+    },
+    {
+      "type": "header",
+      "content": "Section Spacing"
+    },
+    {
+      "type": "range",
+      "id": "section_top_padding",
+      "min": 0,
+      "max": 200,
+      "step": 5,
+      "unit": "px",
+      "label": "Section top padding (desktop)",
+      "default": 10,
+      "info": "Custom top padding for desktop, overrides global spacing"
+    },
+    {
+      "type": "range",
+      "id": "section_top_padding_mobile",
+      "min": 0,
+      "max": 200,
+      "step": 5,
+      "unit": "px",
+      "label": "Section top padding (mobile)",
+      "default": 10,
+      "info": "Custom top padding for mobile, overrides global spacing"
     },
     {
       "type": "header",

--- a/sections/image-with-text.liquid
+++ b/sections/image-with-text.liquid
@@ -613,8 +613,16 @@
     {% if section.settings.enable_fullscreen %}
       padding: 0;
     {% else %}
-      padding: var(--sections-spacing-top) var(--sections-side-space) var(--sections-spacing-bottom);
+      padding: {{ section.settings.section_top_padding | default: 0 }}px var(--sections-side-space) var(--sections-spacing-bottom);
     {% endif %}
+  }
+
+  @media (max-width: 749px) {
+    .image-with-text-media-section-{{ section.id }}{
+      {% unless section.settings.enable_fullscreen %}
+        padding-top: {{ section.settings.section_top_padding_mobile | default: 0 }}px !important;
+      {% endunless %}
+    }
   }
 
   .remove_button_svg .primary-slide-button-arrow{
@@ -1379,6 +1387,28 @@ button.addEventListener('keydown', function(event) {
       "unit": "px",
       "label": "Section height (mobile)",
       "default": 500
+    },
+    {
+      "type": "range",
+      "id": "section_top_padding",
+      "min": 0,
+      "max": 200,
+      "step": 5,
+      "unit": "px",
+      "label": "Section top padding (desktop)",
+      "default": 10,
+      "info": "Overrides global top spacing when fullscreen is disabled"
+    },
+    {
+      "type": "range",
+      "id": "section_top_padding_mobile",
+      "min": 0,
+      "max": 200,
+      "step": 5,
+      "unit": "px",
+      "label": "Section top padding (mobile)",
+      "default": 10,
+      "info": "Overrides global top spacing when fullscreen is disabled on mobile"
     },
     {
       "type": "header",

--- a/sections/main-list-collections.liquid
+++ b/sections/main-list-collections.liquid
@@ -4,8 +4,14 @@
 
 <style>
   .collection-page-wrapper {
-    padding-top: var(--sections-spacing-top) !important;
+    padding-top: {{ section.settings.section_top_padding | default: 0 }}px !important;
     padding-bottom: var(--sections-spacing-bottom) !important;
+  }
+
+  @media (max-width: 749px) {
+    .collection-page-wrapper {
+      padding-top: {{ section.settings.section_top_padding_mobile | default: 0 }}px !important;
+    }
   }
 
   .collection-list {
@@ -374,6 +380,32 @@
       ],
       "default": "2",
       "label": "Columns on mobile"
+    },
+    {
+      "type": "header",
+      "content": "Section Spacing"
+    },
+    {
+      "type": "range",
+      "id": "section_top_padding",
+      "min": 0,
+      "max": 200,
+      "step": 5,
+      "unit": "px",
+      "label": "Section top padding (desktop)",
+      "default": 0,
+      "info": "Custom top padding for desktop, overrides global spacing"
+    },
+    {
+      "type": "range",
+      "id": "section_top_padding_mobile",
+      "min": 0,
+      "max": 200,
+      "step": 5,
+      "unit": "px",
+      "label": "Section top padding (mobile)",
+      "default": 10,
+      "info": "Custom top padding for mobile, overrides global spacing"
     }
   ],
   "blocks": [

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -14,8 +14,14 @@
 
 <style>
   .section-{{ section.id }}-padding {
-    padding-top: var(--sections-spacing-top);
+    padding-top: {{ section.settings.section_top_padding | default: 0 }}px;
     padding-bottom: var(--sections-spacing-bottom);
+  }
+
+  @media (max-width: 749px) {
+    .section-{{ section.id }}-padding {
+      padding-top: {{ section.settings.section_top_padding_mobile | default: 0 }}px !important;
+    }
   }
 
   .product-section-container {
@@ -227,6 +233,32 @@
       "label": "Enable scroll animations",
       "default": true,
       "info": "Animate product title as it scrolls into view. Respects user's motion preferences."
+    },
+    {
+      "type": "header",
+      "content": "Section Spacing"
+    },
+    {
+      "type": "range",
+      "id": "section_top_padding",
+      "min": 0,
+      "max": 200,
+      "step": 5,
+      "unit": "px",
+      "label": "Section top padding (desktop)",
+      "default": 10,
+      "info": "Custom top padding for desktop, overrides global spacing"
+    },
+    {
+      "type": "range",
+      "id": "section_top_padding_mobile",
+      "min": 0,
+      "max": 200,
+      "step": 5,
+      "unit": "px",
+      "label": "Section top padding (mobile)",
+      "default": 10,
+      "info": "Custom top padding for mobile, overrides global spacing"
     }
   ],
   "blocks": [

--- a/sections/scrolling-marquee.liquid
+++ b/sections/scrolling-marquee.liquid
@@ -52,6 +52,32 @@
       "id": "pause_on_hover",
       "label": "Pause on hover",
       "default": false
+    },
+    {
+      "type": "header",
+      "content": "Section Spacing"
+    },
+    {
+      "type": "range",
+      "id": "section_top_padding",
+      "min": 0,
+      "max": 200,
+      "step": 5,
+      "unit": "px",
+      "label": "Section top padding (desktop)",
+      "default": 10,
+      "info": "Custom top padding for desktop, overrides global spacing"
+    },
+    {
+      "type": "range",
+      "id": "section_top_padding_mobile",
+      "min": 0,
+      "max": 200,
+      "step": 5,
+      "unit": "px",
+      "label": "Section top padding (mobile)",
+      "default": 10,
+      "info": "Custom top padding for mobile, overrides global spacing"
     }
   ],
   "presets": [
@@ -139,7 +165,7 @@
 </section>
 
 <style>
-  /* Global spacing applied as margins for marquee section */
+  /* Custom section spacing for marquee section */
   .marquee-wrapper {
     padding: 0;
     display: flex;
@@ -149,9 +175,15 @@
     position: relative;
     height: 30px;
     overflow: hidden;
-    margin-top: var(--sections-spacing-top) !important;
+    margin-top: {{ section.settings.section_top_padding | default: 0 }}px !important;
     margin-bottom: var(--sections-spacing-bottom) !important;
     box-sizing: border-box;
+  }
+
+  @media (max-width: 749px) {
+    .marquee-wrapper {
+      margin-top: {{ section.settings.section_top_padding_mobile | default: 0 }}px !important;
+    }
   }
 
   /* Ensure consistent spacing behavior */

--- a/snippets/new-product-card.liquid
+++ b/snippets/new-product-card.liquid
@@ -280,7 +280,7 @@
     top: 50%;
     transform: translateY(-50%);
     z-index: var(--z-content-elevated);
-    width: 40px;
+    width: 30px;
     height: 40px;
     padding: 6px;
     display: flex;
@@ -298,7 +298,8 @@
   }
 
   .new-image-nav-arrow:hover {
-    background-color: {{ settings.product_card_arrow_hover_bg | default: 'rgba(68, 68, 68, 0.15)' }};
+    background-color: var(--disabled_text);
+    opacity: 0.3;
   }
 
   .new-product-image-wrapper:hover .new-image-nav-arrow svg {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds per-section desktop/mobile top padding controls across key sections and tweaks product card image nav arrow size/hover styling.
> 
> - **Section spacing (desktop/mobile)**
>   - `sections/collection-banner.liquid`: Adds `section_top_padding` and `section_top_padding_mobile` settings; applies via `.section-{{ section.id }}-padding` and media query.
>   - `sections/image-with-text.liquid`: New top padding settings; replaces top padding in `.image-with-text-media-section-*` (non-fullscreen) with section values and mobile override.
>   - `sections/main-list-collections.liquid`: Uses new top padding settings in `.collection-page-wrapper` with mobile override; adds settings to schema.
>   - `sections/main-product.liquid`: Replaces global top spacing with `section_top_padding` and mobile variant; adds settings to schema.
>   - `sections/scrolling-marquee.liquid`: Introduces top padding settings; applies as `margin-top` on `.marquee-wrapper` with mobile override.
> - **Product card UI**
>   - `snippets/new-product-card.liquid`: Reduce nav arrow width from `40px` to `30px`; change hover to `background-color: var(--disabled_text)` with `opacity: 0.3`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ff84d6ee192acec52434e3397bd7171d5e0361d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->