### PR TITLE
size selector + cart drawer + blog post disable feature + cart error issue fixed

### DIFF
--- a/assets/main-article.js
+++ b/assets/main-article.js
@@ -44,6 +44,10 @@ document.addEventListener('DOMContentLoaded', function () {
     subheaders[subheaders.length - 1].classList.add('no-padding-bottom');
   }
 }
+// Check if parallax is enabled
+const parallaxSection = document.querySelector('#parallax-section');
+const isParallaxEnabled = parallaxSection?.dataset.parallaxEnabled === 'true';
+
 const headingEl = document.querySelector('.animated-text');
 const overlay = document.querySelector('.overlay-content');
 const parallaxImage = document.querySelector('.parallax-image-overlay img');
@@ -67,7 +71,8 @@ if (headingEl) {
   if (dateEl) dateEl.style.animationDelay = `${delayTotal + 0.2}s`;
   if (arrowEl) arrowEl.style.animationDelay = `${delayTotal + 0.4}s`;
 
-  if (parallaxImage) {
+  // Only apply parallax image effects if parallax is enabled
+  if (parallaxImage && isParallaxEnabled) {
     parallaxImage.style.position = 'absolute';
     parallaxImage.style.top = '0';
     parallaxImage.style.left = '0';
@@ -81,12 +86,20 @@ if (headingEl) {
       parallaxImage.style.opacity = '1';
       parallaxImage.style.transform = 'translateY(0)';
     }, delayTotal * 1000);
+  } else if (parallaxImage && !isParallaxEnabled) {
+    // Static image - just fade in
+    parallaxImage.style.opacity = '0';
+    parallaxImage.style.transition = 'opacity 1.2s ease-out';
+    
+    setTimeout(() => {
+      parallaxImage.style.opacity = '1';
+    }, delayTotal * 1000);
   }
 }
 
-// ✅ Parallax movement
+// ✅ Parallax movement - only if enabled
 function parallaxScrollEffect() {
-  if (!parallaxImage || !container) return;
+  if (!parallaxImage || !container || !isParallaxEnabled) return;
 
   const rect = container.getBoundingClientRect();
   const scrollY = window.scrollY || window.pageYOffset;
@@ -103,42 +116,45 @@ function onScroll() {
   ticking = false;
   if (!overlay || !container) return;
 
-  const containerRect = container.getBoundingClientRect();
-  const overlayHeight = overlay.offsetHeight;
-  const startParallax = containerRect.top <= OFFSET_TOP;
-  const stopPoint = containerRect.bottom - overlayHeight - OFFSET_TOP;
-  const shouldStopParallax = stopPoint <= OFFSET_TOP;
+  // Only apply parallax scroll effects if enabled
+  if (isParallaxEnabled) {
+    const containerRect = container.getBoundingClientRect();
+    const overlayHeight = overlay.offsetHeight;
+    const startParallax = containerRect.top <= OFFSET_TOP;
+    const stopPoint = containerRect.bottom - overlayHeight - OFFSET_TOP;
+    const shouldStopParallax = stopPoint <= OFFSET_TOP;
 
-  overlay.classList.remove('mobile-fixed', 'mobile-absolute');
+    overlay.classList.remove('mobile-fixed', 'mobile-absolute');
 
-  if (startParallax && !shouldStopParallax) {
-    overlay.style.position = 'fixed';
-    overlay.style.top = `${OFFSET_TOP}px`;
-    overlay.style.zIndex = '2';
-    overlay.style.transform = 'translateZ(0)';
-    overlay.style.width = '100vw';
-    overlay.style.maxWidth = '100vw';
+    if (startParallax && !shouldStopParallax) {
+      overlay.style.position = 'fixed';
+      overlay.style.top = `${OFFSET_TOP}px`;
+      overlay.style.zIndex = '2';
+      overlay.style.transform = 'translateZ(0)';
+      overlay.style.width = '100vw';
+      overlay.style.maxWidth = '100vw';
 
-  } else if (shouldStopParallax) {
-    overlay.style.position = 'absolute';
-    overlay.style.top = `${Math.max(0, container.offsetHeight - overlayHeight - OFFSET_TOP)}px`;
-    overlay.style.zIndex = '';
-    overlay.style.transition = 'none';
-    overlay.style.transform = 'translateY(-20px)';
-    overlay.style.opacity = '1';
-    overlay.style.width = '100vw';
-  } else {
-    overlay.style.position = 'relative';
-    overlay.style.top = '';
-    overlay.style.left = '';
-    overlay.style.width = '';
-    overlay.style.zIndex = '';
-    overlay.style.transform = '';
-    overlay.style.padding = '';
-    overlay.style.maxWidth = '';
+    } else if (shouldStopParallax) {
+      overlay.style.position = 'absolute';
+      overlay.style.top = `${Math.max(0, container.offsetHeight - overlayHeight - OFFSET_TOP)}px`;
+      overlay.style.zIndex = '';
+      overlay.style.transition = 'none';
+      overlay.style.transform = 'translateY(-20px)';
+      overlay.style.opacity = '1';
+      overlay.style.width = '100vw';
+    } else {
+      overlay.style.position = 'relative';
+      overlay.style.top = '';
+      overlay.style.left = '';
+      overlay.style.width = '';
+      overlay.style.zIndex = '';
+      overlay.style.transform = '';
+      overlay.style.padding = '';
+      overlay.style.maxWidth = '';
+    }
+
+    parallaxScrollEffect(); 
   }
-
-  parallaxScrollEffect(); 
 }
 
 function requestTick() {
@@ -158,11 +174,14 @@ function handleOrientationChange() {
   orientationTimeout = setTimeout(requestTick, 100);
 }
 
-window.addEventListener('scroll', requestTick, { passive: true });
-window.addEventListener('resize', handleResize, { passive: true });
-window.addEventListener('orientationchange', handleOrientationChange, { passive: true });
-
-requestTick();
+// Only add parallax scroll listeners if parallax is enabled
+if (isParallaxEnabled) {
+  window.addEventListener('scroll', requestTick, { passive: true });
+  window.addEventListener('resize', handleResize, { passive: true });
+  window.addEventListener('orientationchange', handleOrientationChange, { passive: true });
+  
+  requestTick();
+}
 
 if (parallaxImage && parallaxImage.src) {
   const img = new Image();

--- a/assets/main-cart-items.css
+++ b/assets/main-cart-items.css
@@ -427,6 +427,7 @@
     position: sticky;
     top: 120px;
     min-width: 300px;
+    width: 100%;
     display: flex;
     flex-direction: column;
     gap: 10px;

--- a/sections/main-article.liquid
+++ b/sections/main-article.liquid
@@ -52,15 +52,26 @@
 <section
   id="parallax-section"
   class="section1 color-{{ section.settings.color_scheme }} relative overflow-hidden items-start"
-  style="min-height: 100vh;padding-right:{{ settings.side_space }}px;"
+  {% if section.settings.enable_parallax %}
+    style="min-height: 100vh;padding-right:{{ settings.side_space }}px;"
+  {% else %}
+    style="padding-right:{{ settings.side_space }}px; padding-top: 50px;"
+  {% endif %}
+  data-parallax-enabled="{{ section.settings.enable_parallax }}"
 >
   <div
     class="parallax-container relative"
-    style="min-height: 191.5vh; padding-left:{{ settings.side_space }}px; padding-right:{{ settings.side_space }}px;"
+    {% if section.settings.enable_parallax %}
+      style="min-height: 191.5vh; padding-left:{{ settings.side_space }}px; padding-right:{{ settings.side_space }}px;"
+    {% else %}
+      style="padding-left:{{ settings.side_space }}px; padding-right:{{ settings.side_space }}px;"
+    {% endif %}
   >
-    <div class="overlay-placeholder" style="height: 188vh;"></div>
+    {% if section.settings.enable_parallax %}
+      <div class="overlay-placeholder" style="height: 188vh;"></div>
+    {% endif %}
 
-    <div class="overlay-content max-w-7xl relative flex flex-col" style="margin-top: 1.8vh;">
+    <div class="overlay-content max-w-7xl relative flex flex-col" {% if section.settings.enable_parallax %}style="margin-top: 1.8vh;"{% endif %}>
       {% if section.settings.show_date %}
         <div
           class="ml-4 show_date"
@@ -86,7 +97,11 @@
     {% if article.image %}
       <div
         class="parallax-image-overlay mb-10"
-        style="height: 101.4vh; width:49vw; padding-right:{{ settings.side_space }}px;"
+        {% if section.settings.enable_parallax %}
+          style="height: 101.4vh; width:49vw; padding-right:{{ settings.side_space }}px;"
+        {% else %}
+          style="width:100%; max-width: 1200px; margin: 40px auto; padding-right:{{ settings.side_space }}px;"
+        {% endif %}
       >
         <img
           srcset="
@@ -342,6 +357,13 @@
       "id": "color_scheme",
       "label": "Color Scheme",
       "default": "scheme-1"
+    },
+    {
+      "type": "checkbox",
+      "id": "enable_parallax",
+      "label": "Enable Parallax Effect",
+      "default": true,
+      "info": "Turn on/off the parallax scrolling effect for the article hero image"
     },
     {
       "type": "checkbox",

--- a/snippets/card-product.liquid
+++ b/snippets/card-product.liquid
@@ -802,8 +802,16 @@
 
   /* Style size buttons to match new-product-card */
   .new-size-variants-container .size-btn {
-
+    width: 30px !important;
+    height: 30px !important;
+    min-width: 30px !important;
+    padding: 0 !important;
+    border-radius: var(--sold-out-badge-radius) !important;
+    font-size: var(--t-b-2-size);
+    font-weight: var(--t-b-2-weight);
+    line-height: var(--t-b-2-line-height);
     transform: translateY(10px);
+    cursor: pointer;
   }
 
   .new-size-variants-container .size-btn:hover {
@@ -1330,16 +1338,131 @@
       }
     }
 
+    // Track if we're currently adding to cart to prevent duplicates
+    let isAddingToCart = false;
+
     async function addToCart(formData) {
+      // Prevent duplicate submissions
+      if (isAddingToCart) {
+        console.log('Already adding to cart, skipping duplicate request');
+        return;
+      }
+
+      isAddingToCart = true;
+
       try {
         const response = await fetch(window.routes.cart_add_url, {
           method: 'POST',
           body: formData,
         });
+
         if (!response.ok) throw new Error('Network response was not ok');
-        return await response.json();
+
+        // Check if response is actually JSON
+        const contentType = response.headers.get('content-type');
+        let data;
+
+        if (contentType && contentType.includes('application/json')) {
+          data = await response.json();
+        } else {
+          // If it's not JSON but status is OK, treat as success
+          console.log('Response was not JSON, but treating as success');
+          data = { success: true };
+        }
+
+        // Wait a moment for the cart to update on the server
+        await new Promise((resolve) => setTimeout(resolve, 200));
+
+        // Refresh cart drawer and open it
+        try {
+          await refreshCartDrawer();
+        } catch (refreshError) {
+          console.error('Error refreshing cart drawer:', refreshError);
+          // Even if refresh fails, still try to open the drawer
+        }
+
+        // Open cart drawer after refresh completes
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        openCartDrawer();
+
+        return data;
       } catch (error) {
+        console.error('Error adding to cart:', error);
         throw error;
+      } finally {
+        // Reset the flag after 1 second to allow new additions
+        setTimeout(() => {
+          isAddingToCart = false;
+        }, 1000);
+      }
+    }
+
+    function refreshCartDrawer() {
+      console.log('Refreshing cart drawer...');
+      return fetch(`${window.location.pathname}?section_id=cart-drawer`)
+        .then((response) => {
+          if (!response.ok) {
+            throw new Error(`HTTP error! status: ${response.status}`);
+          }
+          return response.text();
+        })
+        .then((responseText) => {
+          console.log('Cart drawer content fetched successfully');
+          const html = new DOMParser().parseFromString(responseText, 'text/html');
+
+          const cartDrawerElement = document.querySelector('cart-drawer');
+          const newCartDrawerContent = html.querySelector('cart-drawer');
+
+          if (cartDrawerElement && newCartDrawerContent) {
+            const isActive = cartDrawerElement.classList.contains('active');
+            const isAnimating = cartDrawerElement.classList.contains('animate');
+
+            cartDrawerElement.innerHTML = newCartDrawerContent.innerHTML;
+
+            if (isActive) cartDrawerElement.classList.add('active');
+            if (isAnimating) cartDrawerElement.classList.add('animate');
+
+            if (!newCartDrawerContent.classList.contains('is-empty')) {
+              cartDrawerElement.classList.remove('is-empty');
+            } else {
+              cartDrawerElement.classList.add('is-empty');
+            }
+            console.log('Cart drawer updated successfully');
+          } else {
+            console.error('Cart drawer elements not found');
+          }
+
+          const cartIconBubble = document.querySelector('#cart-icon-bubble');
+          const newCartIconBubble = html.querySelector('#cart-icon-bubble');
+
+          if (cartIconBubble && newCartIconBubble) {
+            cartIconBubble.innerHTML = newCartIconBubble.innerHTML;
+          }
+
+          if (typeof initializeCartDrawerQuantities === 'function') {
+            setTimeout(() => initializeCartDrawerQuantities(), 50);
+          }
+        })
+        .catch((error) => {
+          console.error('Error in refreshCartDrawer:', error);
+          throw error;
+        });
+    }
+
+    function openCartDrawer() {
+      const cartDrawer = document.querySelector('cart-drawer');
+      if (cartDrawer) {
+        if (typeof cartDrawer.open === 'function') {
+          cartDrawer.open();
+        } else {
+          // Manually open the cart drawer
+          setTimeout(() => {
+            cartDrawer.classList.add('animate', 'active');
+            document.body.classList.add('overflow-hidden');
+          }, 100);
+        }
+      } else {
+        console.error('Cart drawer element not found');
       }
     }
 
@@ -1370,6 +1493,10 @@
 
         // Handle size button clicks
         sizeVariantsContainer.querySelectorAll('.size-btn').forEach((sizeBtn) => {
+          // Check if listener already attached
+          if (sizeBtn.dataset.listenerAttached) return;
+          sizeBtn.dataset.listenerAttached = 'true';
+
           sizeBtn.addEventListener('click', async () => {
             if (sizeBtn.disabled) return;
 
@@ -1390,19 +1517,24 @@
         });
       } else if (singleVariantId) {
         // For products without size variants
-        addToCartBtn.addEventListener('click', async () => {
-          updateButtonState(addToCartBtn, 'adding');
-          const formData = new FormData();
-          formData.append('id', singleVariantId);
-          formData.append('quantity', '1');
+        // Check if listener already attached
+        if (!addToCartBtn.dataset.listenerAttached) {
+          addToCartBtn.dataset.listenerAttached = 'true';
 
-          try {
-            await addToCart(formData);
-            updateButtonState(addToCartBtn, 'added');
-          } catch (error) {
-            updateButtonState(addToCartBtn, 'default');
-          }
-        });
+          addToCartBtn.addEventListener('click', async () => {
+            updateButtonState(addToCartBtn, 'adding');
+            const formData = new FormData();
+            formData.append('id', singleVariantId);
+            formData.append('quantity', '1');
+
+            try {
+              await addToCart(formData);
+              updateButtonState(addToCartBtn, 'added');
+            } catch (error) {
+              updateButtonState(addToCartBtn, 'default');
+            }
+          });
+        }
       }
     });
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a setting-gated parallax hero for articles with JS fallbacks and improves product card add-to-cart flow to prevent duplicates and auto-refresh/open the cart drawer; minor cart layout tweak.
> 
> - **Article (parallax)**:
>   - Add `enable_parallax` setting in `sections/main-article.liquid` with conditional styles, `data-parallax-enabled`, and optional placeholders.
>   - Update `assets/main-article.js` to read `#parallax-section` dataset, run parallax animations/listeners only when enabled, and fallback to static image fade-in when disabled.
> - **Product card / Cart interaction**:
>   - In `snippets/card-product.liquid` JS: guard against duplicate add-to-cart (`isAddingToCart`), tolerate non-JSON responses, delay and then `refreshCartDrawer()` and `openCartDrawer()`, and update `#cart-icon-bubble`.
>   - Prevent multiple event listener attachments via `data-listener-attached` for size buttons and single-variant buttons; minor size button styling/hover tweaks.
> - **Styles**:
>   - Set `.cart-sidebar` `width: 100%` in `assets/main-cart-items.css`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb1e9180ed04aa01e6902a8977bdc45fc0c1f714. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->