### PR TITLE
Fix footer email signup boxes alignment on desktop - center with 10px…

### DIFF
--- a/assets/footer.css
+++ b/assets/footer.css
@@ -31,18 +31,22 @@ input:focus {
         background-position: 0% 0%;
         background-size: 120% 120%;
     }
+
     25% {
         background-position: 100% 0%;
         background-size: 125% 125%;
     }
+
     50% {
         background-position: 100% 100%;
         background-size: 120% 120%;
     }
+
     75% {
         background-position: 0% 100%;
         background-size: 115% 115%;
     }
+
     100% {
         background-position: 0% 0%;
         background-size: 120% 120%;
@@ -50,34 +54,44 @@ input:focus {
 }
 
 @keyframes grainMove {
+
     0%,
     100% {
         transform: translate(0, 0);
     }
+
     10% {
         transform: translate(-1px, -1px);
     }
+
     20% {
         transform: translate(1px, -1px);
     }
+
     30% {
         transform: translate(-1px, 1px);
     }
+
     40% {
         transform: translate(1px, 1px);
     }
+
     50% {
         transform: translate(-1px, -1px);
     }
+
     60% {
         transform: translate(1px, -1px);
     }
+
     70% {
         transform: translate(-1px, 1px);
     }
+
     80% {
         transform: translate(1px, 1px);
     }
+
     90% {
         transform: translate(-1px, -1px);
     }
@@ -433,6 +447,7 @@ footer .email-input12::placeholder {
 
 /* Desktop - 1024px and up */
 @media (min-width: 1024px) {
+
     /* Icons */
     .email-icon {
         width: 20px;
@@ -539,15 +554,10 @@ footer .email-input12::placeholder {
     }
 
     /* Email Signup */
-    .footer-container .email-signup-section {
-        margin-left: 15px;
-        margin-right: -15px;
-    }
-
     .footer-container .email-signup-section .form-fields-container12 {
-        max-width: calc(100% - 20px);
+        max-width: calc(100% - 30px);
         margin-left: auto;
-        margin-right: auto;
+        margin-right: 0;
     }
 
     .footer-container .email-input12 {


### PR DESCRIPTION
… margins

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Centers the footer email signup fields on tablets and right-aligns them on desktop by adding max-width constraints and margins.
> 
> - **Frontend/CSS**:
>   - **Footer email signup layout (`.form-fields-container12`)**:
>     - *Tablet (≥768px)*: add `max-width: calc(100% - 20px)` and center with `margin-left: auto; margin-right: auto;`.
>     - *Desktop (≥1024px)*: add `max-width: calc(100% - 30px)` and right-align with `margin-left: auto; margin-right: 0;`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3552092796ef996f4b0c85d7d3dd081f4fe0df92. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->