### PR TITLE
blog article parallax disable feature

### DIFF
--- a/sections/main-article.liquid
+++ b/sections/main-article.liquid
@@ -83,6 +83,12 @@
       margin-right: 0 !important;
     }
   }
+
+  /* Set z-index to 0 for image when parallax is disabled */
+  #parallax-section:not([data-parallax-enabled="true"]) .parallax-image-overlay {
+    z-index: 0;
+    position: relative;
+  }
 </style>
 <section
   id="parallax-section"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a data flag and CSS to correctly style the hero image when parallax is disabled.
> 
> - **Frontend (Liquid/CSS)**
>   - `sections/main-article.liquid`:
>     - Add `data-parallax-enabled` attribute on `#parallax-section`.
>     - New CSS rule: when `data-parallax-enabled` is not `true`, set `.parallax-image-overlay` to `z-index: 0` and `position: relative` to adjust hero image layering in non-parallax mode.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e6db9583611224070b6d9efe6745088e5e943de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->