### PR TITLE
localization selector color variable

### DIFF
--- a/snippets/currency-dropdown.liquid
+++ b/snippets/currency-dropdown.liquid
@@ -15,15 +15,13 @@
 
 <div
   class="{% if localPosition == 'FooterCountry' %}disclosure{% endif %} group relative lg:!inline-block "
-  {% if localPosition == 'HeaderCountry' %}
-    style="background: var(--header_background);"
-  {% elsif localPosition == 'FooterCountry' %}
-    {% unless section.settings.enable_transparent %}
+  {% unless section.settings.enable_transparent %}
+    {% if localPosition == 'HeaderCountry' %}
+      style="background: var(--header_background);"
+    {% else %}
       style="background: rgb(var(--color-background));"
-    {% endunless %}
-  {% else %}
-    style="background: rgb(var(--color-background));"
-  {% endif %}
+    {% endif %}
+  {% endunless %}
 >
   <button
     type="button"
@@ -65,16 +63,20 @@
   <div
     class="{% if localPosition == 'FooterCountry' %} bb-ls-disclosure__list-wrapper {% else %} bb-disclosure__list-wrapper {% endif %}disclosure__list-wrapper country-selector"
     hidden
-    {% if localPosition == 'HeaderCountry' %}
-      style="background: var(--header_background);"
-    {% endif %}
+    {% unless section.settings.enable_transparent %}
+      {% if localPosition == 'HeaderCountry' %}
+        style="background: var(--header_background);"
+      {% endif %}
+    {% endunless %}
   >
     <div
       class="bb-disclosure__list disclosure__list country-selector__list{% if show_currencies %} country-selector__list--with-multiple-currencies{% endif %}"
       id="{{ localPosition }}-country-results"
-      {% if localPosition == 'HeaderCountry' %}
-        style="background: var(--header_background);"
-      {% endif %}
+      {% unless section.settings.enable_transparent %}
+        {% if localPosition == 'HeaderCountry' %}
+          style="background: var(--header_background);"
+        {% endif %}
+      {% endunless %}
     >
       {% if show_popular_countries %}
         <ul

--- a/snippets/language-localization.liquid
+++ b/snippets/language-localization.liquid
@@ -15,11 +15,13 @@
 
 <div 
   class="disclosure group relative lg:!inline-block"
-  {% if localPosition == 'HeaderLanguage' %}
-    style="background: var(--header_background);"
-  {% else %}
-    style="background: rgb(var(--color-background));"
-  {% endif %}
+  {% unless section.settings.enable_transparent %}
+    {% if localPosition == 'HeaderLanguage' %}
+      style="background: var(--header_background);"
+    {% else %}
+      style="background: rgb(var(--color-background));"
+    {% endif %}
+  {% endunless %}
 >
   <button
     type="button"
@@ -60,16 +62,20 @@
   <div 
     class="disclosure__list-wrapper language-selector" 
     hidden
-    {% if localPosition == 'HeaderLanguage' %}
-      style="background: var(--header_background);"
-    {% endif %}
+    {% unless section.settings.enable_transparent %}
+      {% if localPosition == 'HeaderLanguage' %}
+        style="background: var(--header_background);"
+      {% endif %}
+    {% endunless %}
   >
     <div
       class="bb-disclosure__list disclosure__list language-selector__list"
       id="{{ localPosition }}List"
-      {% if localPosition == 'HeaderLanguage' %}
-        style="background: var(--header_background);"
-      {% endif %}
+      {% unless section.settings.enable_transparent %}
+        {% if localPosition == 'HeaderLanguage' %}
+          style="background: var(--header_background);"
+        {% endif %}
+      {% endunless %}
     >
       <ul role="list" class="overflow-y-auto divide-y divide-gray-100" style="max-height: 500px; max-width: 400px;">
         {%- for language in localization.available_languages -%}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Apply conditional `--header_background` styling to currency and language dropdowns when rendered in header, respecting transparent setting.
> 
> - **Styling/UX**:
>   - Currency selector (`snippets/currency-dropdown.liquid`):
>     - Conditionally set `style` to `var(--header_background)` for header variant (`localPosition == 'HeaderCountry'`) on the container, list wrapper, and list; fallback to `rgb(var(--color-background))` when not in header; all wrapped in `unless section.settings.enable_transparent`.
>   - Language selector (`snippets/language-localization.liquid`):
>     - Same conditional background application for header variant (`localPosition == 'HeaderLanguage'`) on the container, list wrapper, and list, gated by `enable_transparent`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b79cc815e6095c5892bbe5b4219d9e6c97bd9003. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->