### PR TITLE
size customization

### DIFF
--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -1147,7 +1147,7 @@
         "type": "range",
         "id": "scroll_to_top_icon_size",
         "min": 16,
-        "max": 48,
+        "max": 100,
         "step": 2,
         "unit": "px",
         "label": "Icon Size",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Increase max `scroll_to_top_icon_size` from 48px to 100px in settings schema.
> 
> - **Settings Schema (`config/settings_schema.json`)**:
>   - **Scroll to Top**:
>     - Expand `scroll_to_top_icon_size` `max` from `48px` to `100px`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 743d24fbe2977225de831d101bd0a22c7ec1f970. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->